### PR TITLE
Fix/add right click interact function

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
 kotlin.code.style=official
 kotlin.stdlib.default.dependency=false
 org.gradle.parallel=true
-version=1.21.7-1.1.1-SNAPSHOT
+version=1.21.7-1.2.0-SNAPSHOT

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
 kotlin.code.style=official
 kotlin.stdlib.default.dependency=false
 org.gradle.parallel=true
-version=1.21.7-1.2.0-SNAPSHOT
+version=1.21.7-1.2.1-SNAPSHOT

--- a/surf-npc-bukkit/src/main/kotlin/dev/slne/surf/npc/bukkit/listener/NpcListener.kt
+++ b/surf-npc-bukkit/src/main/kotlin/dev/slne/surf/npc/bukkit/listener/NpcListener.kt
@@ -71,7 +71,7 @@ class NpcListener : PacketListener {
                     }
 
                     WrapperPlayClientInteractEntity.InteractAction.INTERACT -> {
-                        if(packet.hand != InteractionHand.MAIN_HAND) {
+                        if (packet.hand != InteractionHand.MAIN_HAND) {
                             return
                         }
 

--- a/surf-npc-bukkit/src/main/kotlin/dev/slne/surf/npc/bukkit/listener/NpcListener.kt
+++ b/surf-npc-bukkit/src/main/kotlin/dev/slne/surf/npc/bukkit/listener/NpcListener.kt
@@ -60,7 +60,7 @@ class NpcListener : PacketListener {
                 val packet = WrapperPlayClientInteractEntity(event)
                 val npc = npcController.getNpc(packet.entityId) ?: return
 
-                when(packet.action) {
+                when (packet.action) {
                     WrapperPlayClientInteractEntity.InteractAction.ATTACK -> {
                         plugin.launch(plugin.entityDispatcher(player)) {
                             NpcInteractEvent(

--- a/surf-npc-bukkit/src/main/kotlin/dev/slne/surf/npc/bukkit/listener/NpcListener.kt
+++ b/surf-npc-bukkit/src/main/kotlin/dev/slne/surf/npc/bukkit/listener/NpcListener.kt
@@ -3,6 +3,7 @@ package dev.slne.surf.npc.bukkit.listener
 import com.github.retrooper.packetevents.event.PacketListener
 import com.github.retrooper.packetevents.event.PacketReceiveEvent
 import com.github.retrooper.packetevents.protocol.packettype.PacketType
+import com.github.retrooper.packetevents.protocol.player.InteractionHand
 import com.github.retrooper.packetevents.wrapper.play.client.WrapperPlayClientInteractEntity
 import com.github.shynixn.mccoroutine.folia.entityDispatcher
 import com.github.shynixn.mccoroutine.folia.launch
@@ -59,15 +60,31 @@ class NpcListener : PacketListener {
                 val packet = WrapperPlayClientInteractEntity(event)
                 val npc = npcController.getNpc(packet.entityId) ?: return
 
-                if (packet.action != WrapperPlayClientInteractEntity.InteractAction.ATTACK) {
-                    return
-                }
+                when(packet.action) {
+                    WrapperPlayClientInteractEntity.InteractAction.ATTACK -> {
+                        plugin.launch(plugin.entityDispatcher(player)) {
+                            NpcInteractEvent(
+                                npc,
+                                player
+                            ).callEvent()
+                        }
+                    }
 
-                plugin.launch(plugin.entityDispatcher(player)) {
-                    NpcInteractEvent(
-                        npc,
-                        player
-                    ).callEvent()
+                    WrapperPlayClientInteractEntity.InteractAction.INTERACT -> {
+                        if(packet.hand != InteractionHand.MAIN_HAND) {
+                            return
+                        }
+
+                        plugin.launch(plugin.entityDispatcher(player)) {
+                            NpcInteractEvent(
+                                npc,
+                                player
+                            ).callEvent()
+                        }
+                    }
+                    WrapperPlayClientInteractEntity.InteractAction.INTERACT_AT -> {
+                        // This is already handled by INTERACT action, so we can ignore it.
+                    }
                 }
             }
         }


### PR DESCRIPTION
This pull request includes a version update and enhancements to the `NpcListener` class to improve interaction handling for NPCs. The most important changes include updating the project version, adding support for differentiating interaction actions, and ignoring redundant interaction types.

### Version Update:
* [`gradle.properties`](diffhunk://#diff-3d103fc7c312a3e136f88e81cef592424b8af2464c468116545c4d22d6edcf19L4-R4): Updated the project version from `1.21.7-1.1.1-SNAPSHOT` to `1.21.7-1.2.0-SNAPSHOT`.

### Enhancements to NPC Interaction Handling:
* [`NpcListener.kt`](diffhunk://#diff-f8a27632d6ebbb9f5a5b38b0caca50c9cac40274a68799ea6b6a4a51242bca5fR6): Added the `InteractionHand` import to support differentiating between main-hand and off-hand interactions.
* `NpcListener.kt`: Refactored the interaction handling logic in the `NpcListener` class:
  - Introduced a `when` statement to handle different interaction actions (`ATTACK`, `INTERACT`, and `INTERACT_AT`).
  - Added logic to process `ATTACK` actions by launching an `NpcInteractEvent` asynchronously.
  - Enhanced `INTERACT` action handling to ignore interactions performed with the off-hand.
  - Explicitly ignored `INTERACT_AT` actions, as they are already covered by `INTERACT`. [[1]](diffhunk://#diff-f8a27632d6ebbb9f5a5b38b0caca50c9cac40274a68799ea6b6a4a51242bca5fL62-R74) [[2]](diffhunk://#diff-f8a27632d6ebbb9f5a5b38b0caca50c9cac40274a68799ea6b6a4a51242bca5fR85-R89)