### PR TITLE
Feat/8 add surf glowing api support

### DIFF
--- a/surf-npc-api/src/main/kotlin/dev/slne/surf/npc/api/SurfNpcApi.kt
+++ b/surf-npc-api/src/main/kotlin/dev/slne/surf/npc/api/SurfNpcApi.kt
@@ -32,6 +32,8 @@ interface SurfNpcApi {
      * @param rotationType The rotation type of the NPC (default: FIXED).
      * @param fixedRotation The fixed rotation of the NPC, if applicable (default: null).
      * @param persistent Whether the NPC should be persistent (default: false).
+     * @param glowing Whether the NPC should glow (default: false).
+     * @param glowingColor The color of the glow effect (default: NamedTextColor.WHITE).
      * @return The result of the NPC creation.
      */
     fun createNpc(

--- a/surf-npc-api/src/main/kotlin/dev/slne/surf/npc/api/SurfNpcApi.kt
+++ b/surf-npc-api/src/main/kotlin/dev/slne/surf/npc/api/SurfNpcApi.kt
@@ -13,6 +13,7 @@ import dev.slne.surf.surfapi.core.api.util.requiredService
 import it.unimi.dsi.fastutil.objects.ObjectList
 import it.unimi.dsi.fastutil.objects.ObjectSet
 import net.kyori.adventure.text.Component
+import net.kyori.adventure.text.format.NamedTextColor
 import java.util.*
 
 /**
@@ -41,7 +42,9 @@ interface SurfNpcApi {
         global: Boolean = true,
         rotationType: NpcRotationType = NpcRotationType.PER_PLAYER,
         fixedRotation: NpcRotation? = null,
-        persistent: Boolean = false
+        persistent: Boolean = false,
+        glowing: Boolean = false,
+        glowingColor: NamedTextColor = NamedTextColor.WHITE
     ): NpcCreationResult
 
     /**

--- a/surf-npc-api/src/main/kotlin/dev/slne/surf/npc/api/dsl/NpcDslBuilder.kt
+++ b/surf-npc-api/src/main/kotlin/dev/slne/surf/npc/api/dsl/NpcDslBuilder.kt
@@ -158,6 +158,8 @@ fun npc(block: NpcDslBuilder.() -> Unit): NpcCreationResult {
         global = builder.global,
         rotationType = builder.rotationType,
         fixedRotation = builder.fixedRotation,
-        persistent = builder.persistent
+        persistent = builder.persistent,
+        glowing = builder.glowing,
+        glowingColor = builder.glowingColor
     )
 }

--- a/surf-npc-api/src/main/kotlin/dev/slne/surf/npc/api/dsl/NpcDslBuilder.kt
+++ b/surf-npc-api/src/main/kotlin/dev/slne/surf/npc/api/dsl/NpcDslBuilder.kt
@@ -8,6 +8,7 @@ import dev.slne.surf.npc.api.npc.skin.NpcSkin
 import dev.slne.surf.npc.api.result.NpcCreationResult
 import dev.slne.surf.npc.api.surfNpcApi
 import dev.slne.surf.surfapi.core.api.messages.builder.SurfComponentBuilder
+import net.kyori.adventure.text.format.NamedTextColor
 
 /**
  * Builder class for creating NPCs using a DSL.
@@ -52,6 +53,16 @@ class NpcDslBuilder {
      * Whether the NPC should be persistent. Defaults to false.
      */
     var persistent: Boolean = false
+
+    /**
+     * Whether the NPC should glow. Defaults to false.
+     */
+    var glowing: Boolean = false
+
+    /**
+     * The color of the glow effect. Defaults to white.
+     */
+    var glowingColor: NamedTextColor = NamedTextColor.WHITE
 
     /**
      * Configures the skin of the NPC using a DSL block.

--- a/surf-npc-api/src/main/kotlin/dev/slne/surf/npc/api/npc/Npc.kt
+++ b/surf-npc-api/src/main/kotlin/dev/slne/surf/npc/api/npc/Npc.kt
@@ -1,6 +1,7 @@
 package dev.slne.surf.npc.api.npc
 
 import dev.slne.surf.npc.api.npc.property.NpcProperty
+import dev.slne.surf.npc.api.npc.property.NpcPropertyType
 import it.unimi.dsi.fastutil.objects.Object2ObjectMap
 import it.unimi.dsi.fastutil.objects.ObjectSet
 import org.bukkit.entity.Player
@@ -100,6 +101,8 @@ interface Npc {
      * @param property The property to add.
      */
     fun addProperty(property: NpcProperty)
+
+    fun addProperties(vararg properties: Triple<String, Any, NpcPropertyType>)
 
     /**
      * Checks if the NPC is static, meaning it has a persistence property set to true.

--- a/surf-npc-api/src/main/kotlin/dev/slne/surf/npc/api/npc/Npc.kt
+++ b/surf-npc-api/src/main/kotlin/dev/slne/surf/npc/api/npc/Npc.kt
@@ -102,6 +102,11 @@ interface Npc {
      */
     fun addProperty(property: NpcProperty)
 
+    /**
+     * Adds multiple properties to the NPC.
+     *
+     * @param properties A variable number of properties to add, each represented as a Triple containing the key, value, and type.
+     */
     fun addProperties(vararg properties: Triple<String, Any, NpcPropertyType>)
 
     /**

--- a/surf-npc-api/src/main/kotlin/dev/slne/surf/npc/api/npc/property/NpcProperty.kt
+++ b/surf-npc-api/src/main/kotlin/dev/slne/surf/npc/api/npc/property/NpcProperty.kt
@@ -57,5 +57,15 @@ interface NpcProperty {
          * The persistence of the NPC.
          */
         const val PERSISTENCE = "persistence"
+
+        /**
+         * The glowing effect status of the NPC.
+         */
+        const val GLOWING_ENABLED = "glowing_enabled"
+
+        /**
+         * The color of the glowing effect for the NPC.
+         */
+        const val GLOWING_COLOR = "glowing_color"
     }
 }

--- a/surf-npc-bukkit/src/main/kotlin/dev/slne/surf/npc/bukkit/api/BukkitSurfNpcApi.kt
+++ b/surf-npc-bukkit/src/main/kotlin/dev/slne/surf/npc/bukkit/api/BukkitSurfNpcApi.kt
@@ -21,6 +21,7 @@ import dev.slne.surf.npc.core.property.propertyTypeRegistry
 import it.unimi.dsi.fastutil.objects.ObjectList
 import it.unimi.dsi.fastutil.objects.ObjectSet
 import net.kyori.adventure.text.Component
+import net.kyori.adventure.text.format.NamedTextColor
 import net.kyori.adventure.util.Services
 import java.util.*
 
@@ -34,7 +35,9 @@ class BukkitSurfNpcApi : SurfNpcApi, Services.Fallback {
         global: Boolean,
         rotationType: NpcRotationType,
         fixedRotation: NpcRotation?,
-        persistent: Boolean
+        persistent: Boolean,
+        glowing: Boolean,
+        glowingColor: NamedTextColor
     ): NpcCreationResult {
         return npcController.createNpc(
             uniqueName,
@@ -44,7 +47,9 @@ class BukkitSurfNpcApi : SurfNpcApi, Services.Fallback {
             rotationType,
             fixedRotation ?: BukkitNpcRotation(0f, 0f),
             global,
-            persistent
+            persistent,
+            glowing,
+            glowingColor
         )
     }
 

--- a/surf-npc-bukkit/src/main/kotlin/dev/slne/surf/npc/bukkit/controller/BukkitNpcController.kt
+++ b/surf-npc-bukkit/src/main/kotlin/dev/slne/surf/npc/bukkit/controller/BukkitNpcController.kt
@@ -26,6 +26,7 @@ import dev.slne.surf.surfapi.core.api.util.*
 import it.unimi.dsi.fastutil.objects.ObjectList
 import it.unimi.dsi.fastutil.objects.ObjectSet
 import net.kyori.adventure.text.Component
+import net.kyori.adventure.text.format.NamedTextColor
 import net.kyori.adventure.util.Services
 import java.util.*
 
@@ -41,7 +42,9 @@ class BukkitNpcController : NpcController, Services.Fallback {
         rotationType: NpcRotationType,
         rotation: NpcRotation,
         global: Boolean,
-        persistent: Boolean
+        persistent: Boolean,
+        glowing: Boolean,
+        glowingColor: NamedTextColor
     ): NpcCreationResult {
         val id = random.nextInt()
         val nameTagId = random.nextInt()
@@ -66,70 +69,62 @@ class BukkitNpcController : NpcController, Services.Fallback {
             uniqueName
         )
 
-        npc.addProperty(
-            BukkitNpcProperty(
-                NpcProperty.Internal.DISPLAYNAME, displayName, propertyTypeRegistry.get(
-                    NpcPropertyType.Types.COMPONENT
-                ) ?: error("Component property type not found")
-            )
-        )
-        npc.addProperty(
-            BukkitNpcProperty(
-                NpcProperty.Internal.SKIN_OWNER, skinData.ownerName, propertyTypeRegistry.get(
-                    NpcPropertyType.Types.STRING
-                ) ?: error("STRING property type not found")
-            )
-        )
-        npc.addProperty(
-            BukkitNpcProperty(
-                NpcProperty.Internal.SKIN_TEXTURE, skinData.value, propertyTypeRegistry.get(
-                    NpcPropertyType.Types.STRING
-                ) ?: error("STRING property type not found")
-            )
-        )
-        npc.addProperty(
-            BukkitNpcProperty(
-                NpcProperty.Internal.SKIN_SIGNATURE, skinData.signature, propertyTypeRegistry.get(
-                    NpcPropertyType.Types.STRING
-                ) ?: error("STRING property type not found")
-            )
-        )
-        npc.addProperty(
-            BukkitNpcProperty(
-                NpcProperty.Internal.LOCATION, location, propertyTypeRegistry.get(
-                    NpcPropertyType.Types.NPC_LOCATION
-                ) ?: error("LOCATION property type not found")
-            )
-        )
-        npc.addProperty(
-            BukkitNpcProperty(
+        val componentType = propertyTypeRegistry.get(
+            NpcPropertyType.Types.COMPONENT
+        ) ?: error("Component property type not found")
+
+        val booleanType = propertyTypeRegistry.get(
+            NpcPropertyType.Types.BOOLEAN
+        ) ?: error("BOOLEAN property type not found")
+
+        val stringType = propertyTypeRegistry.get(
+            NpcPropertyType.Types.STRING
+        ) ?: error("STRING property type not found")
+        val npcLocationType = propertyTypeRegistry.get(
+            NpcPropertyType.Types.NPC_LOCATION
+        ) ?: error("NPC_LOCATION property type not found")
+        val npcRotationPropertyType = propertyTypeRegistry.get(
+            NpcPropertyType.Types.NPC_ROTATION
+        ) ?: error("NPC_ROTATION property type not found")
+        val namedTextColorType = propertyTypeRegistry.get(
+            NpcPropertyType.Types.NAMED_TEXT_COLOR
+        ) ?: error("NAMED_TEXT_COLOR property type not found")
+
+        npc.addProperties(
+            Triple(
+            NpcProperty.Internal.DISPLAYNAME, displayName, componentType
+            ),
+            Triple(
+                NpcProperty.Internal.SKIN_OWNER, skinData.ownerName, stringType
+            ),
+            Triple(
+                NpcProperty.Internal.SKIN_TEXTURE, skinData.value, stringType
+            ),
+            Triple(
+                NpcProperty.Internal.SKIN_SIGNATURE, skinData.signature, stringType
+            ),
+            Triple(
+                NpcProperty.Internal.LOCATION, location, npcLocationType
+            ),
+            Triple(
                 NpcProperty.Internal.ROTATION_TYPE,
                 rotationType == NpcRotationType.PER_PLAYER,
-                propertyTypeRegistry.get(
-                    NpcPropertyType.Types.BOOLEAN
-                ) ?: error("BOOLEAN property type not found")
-            )
-        )
-        npc.addProperty(
-            BukkitNpcProperty(
-                NpcProperty.Internal.ROTATION_FIXED, rotation, propertyTypeRegistry.get(
-                    NpcPropertyType.Types.NPC_ROTATION
-                ) ?: error("ROTATION property type not found")
-            )
-        )
-        npc.addProperty(
-            BukkitNpcProperty(
-                NpcProperty.Internal.VISIBILITY_GLOBAL, global, propertyTypeRegistry.get(
-                    NpcPropertyType.Types.BOOLEAN
-                ) ?: error("BOOLEAN property type not found")
-            )
-        )
-
-        npc.addProperty(
-            BukkitNpcProperty(
-                NpcProperty.Internal.PERSISTENCE, persistent, propertyTypeRegistry.get(
-                    NpcPropertyType.Types.BOOLEAN
-                ) ?: error("BOOLEAN property type not found")
+                booleanType
+            ),
+            Triple(
+                NpcProperty.Internal.ROTATION_FIXED, rotation, npcRotationPropertyType
+            ),
+            Triple(
+                NpcProperty.Internal.VISIBILITY_GLOBAL, global, booleanType
+            ),
+            Triple(
+                NpcProperty.Internal.PERSISTENCE, persistent, booleanType
+            ),
+            Triple(
+                NpcProperty.Internal.GLOWING_ENABLED, glowing, booleanType
+            ),
+            Triple(
+                NpcProperty.Internal.GLOWING_COLOR, glowingColor, namedTextColorType
             )
         )
 

--- a/surf-npc-bukkit/src/main/kotlin/dev/slne/surf/npc/bukkit/npc/BukkitNpc.kt
+++ b/surf-npc-bukkit/src/main/kotlin/dev/slne/surf/npc/bukkit/npc/BukkitNpc.kt
@@ -65,9 +65,9 @@ class BukkitNpc(
         val location =
             this.getPropertyValue(NpcProperty.Internal.LOCATION, NpcLocation::class) ?: return
 
-        val glowing = this.getPropertyValue("glowing", Boolean::class) ?: false
+        val glowing = this.getPropertyValue(NpcProperty.Internal.GLOWING_ENABLED, Boolean::class) ?: false
         val glowingColor =
-            this.getPropertyValue("glowing_color", NamedTextColor::class) ?: NamedTextColor.WHITE
+            this.getPropertyValue(NpcProperty.Internal.GLOWING_COLOR, NamedTextColor::class) ?: NamedTextColor.WHITE
 
         profile.textureProperties.add(
             TextureProperty(
@@ -101,7 +101,7 @@ class BukkitNpc(
         user.sendPacket(createNametagMetadataPacket(nameTagId, displayName))
 
         if (glowing) {
-            glowingApi.makeGlowing(id, "npc_$id-glow", player, glowingColor)
+            glowingApi.makeGlowing(id, "npc_$id", player, glowingColor)
         }
 
         plugin.launch(plugin.entityDispatcher(player)) {
@@ -264,6 +264,10 @@ class BukkitNpc(
     override fun addProperty(property: NpcProperty) {
         properties[property.key] = property
     }
+
+    override fun addProperties(vararg properties: Triple<String, Any, NpcPropertyType>) = properties
+            .map { BukkitNpcProperty(it.first, it.second, it.third) }
+            .forEach { this.addProperty(it) }
 
     override fun addProperties(vararg properties: NpcProperty) {
         properties.forEach {

--- a/surf-npc-core/src/main/kotlin/dev/slne/surf/npc/core/controller/NpcController.kt
+++ b/surf-npc-core/src/main/kotlin/dev/slne/surf/npc/core/controller/NpcController.kt
@@ -14,6 +14,7 @@ import dev.slne.surf.surfapi.core.api.util.requiredService
 import it.unimi.dsi.fastutil.objects.ObjectList
 import it.unimi.dsi.fastutil.objects.ObjectSet
 import net.kyori.adventure.text.Component
+import net.kyori.adventure.text.format.NamedTextColor
 import java.util.*
 
 /**
@@ -41,7 +42,9 @@ interface NpcController {
         rotationType: NpcRotationType,
         rotation: NpcRotation,
         global: Boolean,
-        persistent: Boolean = false
+        persistent: Boolean = false,
+        glowing: Boolean = false,
+        glowingColor: NamedTextColor = NamedTextColor.WHITE
     ): NpcCreationResult
 
     /**

--- a/surf-npc-example-dsl/src/main/kotlin/dev/slne/surf/npc/example/SurfNpcExamplePlugin.kt
+++ b/surf-npc-example-dsl/src/main/kotlin/dev/slne/surf/npc/example/SurfNpcExamplePlugin.kt
@@ -8,6 +8,7 @@ import dev.slne.surf.npc.api.npc.rotation.NpcRotationType
 import dev.slne.surf.npc.api.surfNpcApi
 import dev.slne.surf.npc.example.listener.ExampleNpcListener
 import dev.slne.surf.surfapi.core.api.util.logger
+import net.kyori.adventure.text.format.NamedTextColor
 import net.kyori.adventure.text.minimessage.MiniMessage
 import org.bukkit.Bukkit
 
@@ -49,6 +50,8 @@ class SurfNpcExamplePlugin() : SuspendingJavaPlugin() {
             global = true
             rotationType = NpcRotationType.PER_PLAYER
             persistent = false // This is already the default value, but can be set explicitly if needed.
+            glowing = true
+            glowingColor = NamedTextColor.RED
         }
 
         /**

--- a/surf-npc-example/src/main/kotlin/dev/slne/surf/npc/example/SurfNpcExamplePlugin.kt
+++ b/surf-npc-example/src/main/kotlin/dev/slne/surf/npc/example/SurfNpcExamplePlugin.kt
@@ -2,7 +2,6 @@ package dev.slne.surf.npc.example
 
 import com.github.shynixn.mccoroutine.folia.SuspendingJavaPlugin
 import dev.slne.surf.npc.api.npc.property.NpcPropertyType
-import dev.slne.surf.npc.api.npc.rotation.NpcRotationType
 import dev.slne.surf.npc.api.npc.skin.NpcSkin
 import dev.slne.surf.npc.api.surfNpcApi
 import dev.slne.surf.npc.example.listener.ExampleNpcListener
@@ -18,9 +17,7 @@ class SurfNpcExamplePlugin() : SuspendingJavaPlugin() {
             MiniMessage.miniMessage().deserialize("<rainbow>Example Npc by surf-npc-example"),
             "example_npc",
             createSkinData(),
-            surfNpcApi.createLocation(0.0, 0.0, 0.0, "world"),
-            true,
-            NpcRotationType.PER_PLAYER
+            surfNpcApi.createLocation(0.0, 0.0, 0.0, "world")
         )
 
         val npc = surfNpcApi.getNpc("example_npc") ?: return run {


### PR DESCRIPTION
This pull request introduces a new feature to support glowing NPCs with customizable glow colors in the `surf-npc-api` and its related modules. The changes include updates to the API, DSL, and core implementations to accommodate the glowing effect and its properties.

### API Enhancements:
* Added `glowing` and `glowingColor` parameters to the `createNpc` method in the `SurfNpcApi` interface, with default values of `false` and `NamedTextColor.WHITE`, respectively. [[1]](diffhunk://#diff-8921ec879557f547e29181ae9c86a51fb3aae6be796ba4c7955205f24fe25c0cR35-R36) [[2]](diffhunk://#diff-8921ec879557f547e29181ae9c86a51fb3aae6be796ba4c7955205f24fe25c0cL44-R49)
* Introduced a new method `addProperties` in the `Npc` interface to allow adding multiple properties at once.

### DSL Updates:
* Added `glowing` and `glowingColor` properties to the `NpcDslBuilder` class for configuring glowing NPCs.
* Updated the `npc` DSL function to pass the `glowing` and `glowingColor` properties to the `createNpc` method.

### Core Implementation Changes:
* Updated the `NpcController` and `BukkitNpcController` to handle the new `glowing` and `glowingColor` properties during NPC creation. [[1]](diffhunk://#diff-d659957c55b78562c2d95d2a57d3dc7581b041b6f2ba4147a8a32201ab306efcL44-R47) [[2]](diffhunk://#diff-bf0d29a70638b78f346a0543eea99452e961443fe41a45753a8e909631b58bfdL44-R47)
* Refactored property handling in `BukkitNpcController` to use the new `addProperties` method for better scalability and maintainability.

### Property Definitions:
* Added constants for `GLOWING_ENABLED` and `GLOWING_COLOR` to the `NpcProperty` interface.

### Example Updates:
* Updated example plugins to demonstrate the new glowing NPC feature, including setting `glowing = true` and `glowingColor = NamedTextColor.RED`.

resolves #8 