### PR TITLE
Feat/7 add entity animations

### DIFF
--- a/surf-npc-api/src/main/kotlin/dev/slne/surf/npc/api/SurfNpcApi.kt
+++ b/surf-npc-api/src/main/kotlin/dev/slne/surf/npc/api/SurfNpcApi.kt
@@ -1,6 +1,7 @@
 package dev.slne.surf.npc.api
 
 import dev.slne.surf.npc.api.npc.Npc
+import dev.slne.surf.npc.api.npc.animation.NpcAnimationType
 import dev.slne.surf.npc.api.npc.location.NpcLocation
 import dev.slne.surf.npc.api.npc.property.NpcProperty
 import dev.slne.surf.npc.api.npc.property.NpcPropertyType
@@ -231,6 +232,13 @@ interface SurfNpcApi {
      * @return The found property type or null if not present.
      */
     fun getPropertyType(id: String): NpcPropertyType?
+
+    /**
+     * Plays an animation on the specified NPC.
+     *
+     * @param npc The NPC on which the animation will be played.
+     */
+    fun playAnimation(npc: Npc, animationType: NpcAnimationType)
 
     companion object {
         /**

--- a/surf-npc-api/src/main/kotlin/dev/slne/surf/npc/api/npc/Npc.kt
+++ b/surf-npc-api/src/main/kotlin/dev/slne/surf/npc/api/npc/Npc.kt
@@ -1,5 +1,6 @@
 package dev.slne.surf.npc.api.npc
 
+import dev.slne.surf.npc.api.npc.animation.NpcAnimationType
 import dev.slne.surf.npc.api.npc.property.NpcProperty
 import it.unimi.dsi.fastutil.objects.Object2ObjectMap
 import it.unimi.dsi.fastutil.objects.ObjectSet
@@ -158,4 +159,12 @@ interface Npc {
      * @return True if the NPC has properties, false otherwise.
      */
     fun hasProperties(): Boolean
+
+
+    /**
+     * Plays an animation on the NPC.
+     *
+     * @param animationType The type of animation to play.
+     */
+    fun playAnimation(animationType: NpcAnimationType)
 }

--- a/surf-npc-api/src/main/kotlin/dev/slne/surf/npc/api/npc/animation/NpcAnimationType.kt
+++ b/surf-npc-api/src/main/kotlin/dev/slne/surf/npc/api/npc/animation/NpcAnimationType.kt
@@ -1,0 +1,10 @@
+package dev.slne.surf.npc.api.npc.animation
+
+enum class NpcAnimationType {
+    SWING_ARM_MAIN,
+    SWING_ARM_OFF,
+    GET_DAMAGE,
+    LEAVE_BED,
+    HIT_CRITICAL,
+    HIT_MAGIC
+}

--- a/surf-npc-bukkit/src/main/kotlin/dev/slne/surf/npc/bukkit/BukkitPackets.kt
+++ b/surf-npc-bukkit/src/main/kotlin/dev/slne/surf/npc/bukkit/BukkitPackets.kt
@@ -7,6 +7,7 @@ import com.github.retrooper.packetevents.protocol.player.GameMode
 import com.github.retrooper.packetevents.protocol.player.UserProfile
 import com.github.retrooper.packetevents.util.Vector3d
 import com.github.retrooper.packetevents.wrapper.play.server.*
+import dev.slne.surf.npc.api.npc.animation.NpcAnimationType
 import io.github.retrooper.packetevents.util.SpigotConversionUtil
 import net.kyori.adventure.text.Component
 import net.kyori.adventure.text.format.NamedTextColor
@@ -127,3 +128,15 @@ fun createTeleportPacket(entityId: Int, location: Location, onGround: Boolean = 
         SpigotConversionUtil.fromBukkitLocation(location),
         onGround
     )
+
+fun createEntityAnimation(entityId: Int, animation: NpcAnimationType) = WrapperPlayServerEntityAnimation(
+    entityId,
+    when (animation) {
+        NpcAnimationType.SWING_ARM_MAIN -> WrapperPlayServerEntityAnimation.EntityAnimationType.SWING_MAIN_ARM
+        NpcAnimationType.SWING_ARM_OFF -> WrapperPlayServerEntityAnimation.EntityAnimationType.SWING_OFF_HAND
+        NpcAnimationType.GET_DAMAGE -> WrapperPlayServerEntityAnimation.EntityAnimationType.HURT
+        NpcAnimationType.LEAVE_BED -> WrapperPlayServerEntityAnimation.EntityAnimationType.WAKE_UP
+        NpcAnimationType.HIT_CRITICAL -> WrapperPlayServerEntityAnimation.EntityAnimationType.CRITICAL_HIT
+        NpcAnimationType.HIT_MAGIC -> WrapperPlayServerEntityAnimation.EntityAnimationType.MAGIC_CRITICAL_HIT
+    }
+)

--- a/surf-npc-bukkit/src/main/kotlin/dev/slne/surf/npc/bukkit/api/BukkitSurfNpcApi.kt
+++ b/surf-npc-bukkit/src/main/kotlin/dev/slne/surf/npc/bukkit/api/BukkitSurfNpcApi.kt
@@ -3,6 +3,7 @@ package dev.slne.surf.npc.bukkit.api
 import com.google.auto.service.AutoService
 import dev.slne.surf.npc.api.SurfNpcApi
 import dev.slne.surf.npc.api.npc.Npc
+import dev.slne.surf.npc.api.npc.animation.NpcAnimationType
 import dev.slne.surf.npc.api.npc.location.NpcLocation
 import dev.slne.surf.npc.api.npc.property.NpcProperty
 import dev.slne.surf.npc.api.npc.property.NpcPropertyType
@@ -155,5 +156,12 @@ class BukkitSurfNpcApi : SurfNpcApi, Services.Fallback {
 
     override fun getPropertyType(id: String): NpcPropertyType? {
         return propertyTypeRegistry.get(id)
+    }
+
+    override fun playAnimation(
+        npc: Npc,
+        animationType: NpcAnimationType
+    ) {
+        npcController.playAnimation(npc, animationType)
     }
 }

--- a/surf-npc-bukkit/src/main/kotlin/dev/slne/surf/npc/bukkit/command/NpcCommand.kt
+++ b/surf-npc-bukkit/src/main/kotlin/dev/slne/surf/npc/bukkit/command/NpcCommand.kt
@@ -26,5 +26,6 @@ class NpcCommand(commandName: String) : CommandAPICommand(commandName) {
         subcommand(NpcReloadFromDiskCommand("loadFromDisk"))
         subcommand(NpcSaveToDiskCommand("saveToDisk"))
         subcommand(NpcRefreshCommand("refresh"))
+        subcommand(NpcAnimateCommand("animate"))
     }
 }

--- a/surf-npc-bukkit/src/main/kotlin/dev/slne/surf/npc/bukkit/command/argument/NpcAnimationTypeArgument.kt
+++ b/surf-npc-bukkit/src/main/kotlin/dev/slne/surf/npc/bukkit/command/argument/NpcAnimationTypeArgument.kt
@@ -1,0 +1,29 @@
+package dev.slne.surf.npc.bukkit.command.argument
+
+import dev.jorel.commandapi.CommandAPICommand
+import dev.jorel.commandapi.arguments.Argument
+import dev.jorel.commandapi.arguments.ArgumentSuggestions
+import dev.jorel.commandapi.arguments.CustomArgument
+import dev.jorel.commandapi.arguments.StringArgument
+import dev.slne.surf.npc.api.npc.animation.NpcAnimationType
+import dev.slne.surf.npc.api.npc.property.NpcPropertyType
+import dev.slne.surf.npc.core.property.propertyTypeRegistry
+import dev.slne.surf.surfapi.core.api.messages.adventure.buildText
+
+class NpcAnimationTypeArgument(nodeName: String) :
+    CustomArgument<NpcAnimationType, String>(StringArgument(nodeName), { info ->
+        NpcAnimationType.valueOf(info.input.uppercase())
+    }) {
+    init {
+        replaceSuggestions(ArgumentSuggestions.stringCollection {
+            NpcAnimationType.entries.map { it.name.lowercase() }
+        })
+    }
+}
+
+inline fun CommandAPICommand.npcAnimationTypeArgument(
+    nodeName: String,
+    optional: Boolean = false,
+    block: Argument<*>.() -> Unit = {}
+): CommandAPICommand =
+    withArguments(NpcAnimationTypeArgument(nodeName).setOptional(optional).apply(block))

--- a/surf-npc-bukkit/src/main/kotlin/dev/slne/surf/npc/bukkit/command/argument/NpcAnimationTypeArgument.kt
+++ b/surf-npc-bukkit/src/main/kotlin/dev/slne/surf/npc/bukkit/command/argument/NpcAnimationTypeArgument.kt
@@ -6,9 +6,6 @@ import dev.jorel.commandapi.arguments.ArgumentSuggestions
 import dev.jorel.commandapi.arguments.CustomArgument
 import dev.jorel.commandapi.arguments.StringArgument
 import dev.slne.surf.npc.api.npc.animation.NpcAnimationType
-import dev.slne.surf.npc.api.npc.property.NpcPropertyType
-import dev.slne.surf.npc.core.property.propertyTypeRegistry
-import dev.slne.surf.surfapi.core.api.messages.adventure.buildText
 
 class NpcAnimationTypeArgument(nodeName: String) :
     CustomArgument<NpcAnimationType, String>(StringArgument(nodeName), { info ->

--- a/surf-npc-bukkit/src/main/kotlin/dev/slne/surf/npc/bukkit/command/sub/NpcAnimateCommand.kt
+++ b/surf-npc-bukkit/src/main/kotlin/dev/slne/surf/npc/bukkit/command/sub/NpcAnimateCommand.kt
@@ -1,0 +1,35 @@
+package dev.slne.surf.npc.bukkit.command.sub
+
+import dev.jorel.commandapi.CommandAPICommand
+import dev.jorel.commandapi.kotlindsl.getValue
+import dev.jorel.commandapi.kotlindsl.playerExecutor
+import dev.slne.surf.npc.api.npc.Npc
+import dev.slne.surf.npc.api.npc.animation.NpcAnimationType
+import dev.slne.surf.npc.bukkit.command.argument.npcAnimationTypeArgument
+import dev.slne.surf.npc.bukkit.command.argument.npcArgument
+import dev.slne.surf.npc.bukkit.util.PermissionRegistry
+import dev.slne.surf.npc.core.controller.npcController
+import dev.slne.surf.surfapi.core.api.messages.adventure.sendText
+
+class NpcAnimateCommand(commandName: String): CommandAPICommand(commandName) {
+    init {
+        withPermission(PermissionRegistry.COMMAND_NPC_ANIMATE)
+        npcArgument("npc")
+        npcAnimationTypeArgument("animationType")
+        playerExecutor { player, args ->
+            val npc: Npc by args
+            val animationType: NpcAnimationType by args
+
+            npcController.playAnimation(npc, animationType)
+
+            player.sendText {
+                appendPrefix()
+                success("Die Animation ")
+                variableValue(animationType.name)
+                success(" wurde für den Npc ")
+                variableValue(npc.uniqueName)
+                success(" abgespielt.")
+            }
+        }
+    }
+}

--- a/surf-npc-bukkit/src/main/kotlin/dev/slne/surf/npc/bukkit/controller/BukkitNpcController.kt
+++ b/surf-npc-bukkit/src/main/kotlin/dev/slne/surf/npc/bukkit/controller/BukkitNpcController.kt
@@ -6,6 +6,7 @@ import com.google.auto.service.AutoService
 import dev.slne.surf.npc.api.event.NpcCreateEvent
 import dev.slne.surf.npc.api.event.NpcDeleteEvent
 import dev.slne.surf.npc.api.npc.Npc
+import dev.slne.surf.npc.api.npc.animation.NpcAnimationType
 import dev.slne.surf.npc.api.npc.location.NpcLocation
 import dev.slne.surf.npc.api.npc.property.NpcProperty
 import dev.slne.surf.npc.api.npc.property.NpcPropertyType
@@ -355,5 +356,12 @@ class BukkitNpcController : NpcController, Services.Fallback {
 
         npc.removeProperty(key)
         return true
+    }
+
+    override fun playAnimation(
+        npc: Npc,
+        animationType: NpcAnimationType
+    ) {
+        npc.playAnimation(animationType)
     }
 }

--- a/surf-npc-bukkit/src/main/kotlin/dev/slne/surf/npc/bukkit/npc/BukkitNpc.kt
+++ b/surf-npc-bukkit/src/main/kotlin/dev/slne/surf/npc/bukkit/npc/BukkitNpc.kt
@@ -299,7 +299,7 @@ class BukkitNpc(
         val global =
             this.getPropertyValue(NpcProperty.Internal.VISIBILITY_GLOBAL, Boolean::class) ?: false
 
-        if(global) {
+        if (global) {
             forEachPlayer {
                 playerManager.getUser(it).sendPacket(createEntityAnimation(id, animationType))
             }

--- a/surf-npc-bukkit/src/main/kotlin/dev/slne/surf/npc/bukkit/npc/BukkitNpc.kt
+++ b/surf-npc-bukkit/src/main/kotlin/dev/slne/surf/npc/bukkit/npc/BukkitNpc.kt
@@ -9,6 +9,7 @@ import com.github.shynixn.mccoroutine.folia.launch
 import dev.slne.surf.npc.api.event.NpcDespawnEvent
 import dev.slne.surf.npc.api.event.NpcSpawnEvent
 import dev.slne.surf.npc.api.npc.Npc
+import dev.slne.surf.npc.api.npc.animation.NpcAnimationType
 import dev.slne.surf.npc.api.npc.location.NpcLocation
 import dev.slne.surf.npc.api.npc.property.NpcProperty
 import dev.slne.surf.npc.api.npc.property.NpcPropertyType
@@ -289,6 +290,27 @@ class BukkitNpc(
 
     override fun hasProperties(): Boolean {
         return properties.isNotEmpty()
+    }
+
+    override fun playAnimation(animationType: NpcAnimationType) {
+        val packetEvents = PacketEvents.getAPI()
+        val playerManager = packetEvents.playerManager
+
+        val global =
+            this.getPropertyValue(NpcProperty.Internal.VISIBILITY_GLOBAL, Boolean::class) ?: false
+
+        if(global) {
+            forEachPlayer {
+                playerManager.getUser(it).sendPacket(createEntityAnimation(id, animationType))
+            }
+        } else {
+            for (viewer in viewers) {
+                val player = Bukkit.getPlayer(viewer) ?: continue
+                val user = playerManager.getUser(player)
+
+                user.sendPacket(createEntityAnimation(id, animationType))
+            }
+        }
     }
 
     override fun <T : Any> getPropertyValue(key: String, clazz: KClass<T>): T? {

--- a/surf-npc-bukkit/src/main/kotlin/dev/slne/surf/npc/bukkit/util/PermissionRegistry.kt
+++ b/surf-npc-bukkit/src/main/kotlin/dev/slne/surf/npc/bukkit/util/PermissionRegistry.kt
@@ -9,6 +9,7 @@ object PermissionRegistry : PermissionRegistry() {
     val COMMAND_NPC_CREATE = create("$PREFIX.command.create")
     val COMMAND_NPC_DELETE = create("$PREFIX.command.delete")
     val COMMAND_NPC_REFRESH = create("$PREFIX.command.refresh")
+    val COMMAND_NPC_ANIMATE = create("$PREFIX.command.animate")
 
     val COMMAND_NPC_LIST = create("$PREFIX.command.list")
     val COMMAND_NPC_INFO = create("$PREFIX.command.info")

--- a/surf-npc-core/src/main/kotlin/dev/slne/surf/npc/core/controller/NpcController.kt
+++ b/surf-npc-core/src/main/kotlin/dev/slne/surf/npc/core/controller/NpcController.kt
@@ -1,6 +1,7 @@
 package dev.slne.surf.npc.core.controller
 
 import dev.slne.surf.npc.api.npc.Npc
+import dev.slne.surf.npc.api.npc.animation.NpcAnimationType
 import dev.slne.surf.npc.api.npc.location.NpcLocation
 import dev.slne.surf.npc.api.npc.property.NpcProperty
 import dev.slne.surf.npc.api.npc.rotation.NpcRotation
@@ -173,6 +174,8 @@ interface NpcController {
      * @return True if the property was removed successfully, false otherwise.
      */
     fun removeProperty(npc: Npc, key: String): Boolean
+
+    fun playAnimation(npc: Npc, animationType: NpcAnimationType)
 
     companion object {
         /**

--- a/surf-npc-core/src/main/kotlin/dev/slne/surf/npc/core/controller/NpcController.kt
+++ b/surf-npc-core/src/main/kotlin/dev/slne/surf/npc/core/controller/NpcController.kt
@@ -175,6 +175,12 @@ interface NpcController {
      */
     fun removeProperty(npc: Npc, key: String): Boolean
 
+    /**
+     * Plays an animation on an NPC.
+     *
+     * @param npc The NPC on which to play the animation.
+     * @param animationType The type of animation to play.
+     */
     fun playAnimation(npc: Npc, animationType: NpcAnimationType)
 
     companion object {


### PR DESCRIPTION
This pull request introduces a new feature to enable animations for NPCs in the system. It includes updates to the core API, Bukkit implementation, and command system to support this functionality. The most important changes involve adding the `NpcAnimationType` enum, methods for triggering animations, and commands for users to interact with this feature.

### Core API Enhancements:
* Added `NpcAnimationType` enum to define various animation types such as `SWING_ARM_MAIN`, `GET_DAMAGE`, and `HIT_CRITICAL` (`surf-npc-api/src/main/kotlin/dev/slne/surf/npc/api/npc/animation/NpcAnimationType.kt`).
* Introduced `playAnimation` method in `Npc` and `SurfNpcApi` interfaces to allow animations to be triggered on NPCs (`surf-npc-api/src/main/kotlin/dev/slne/surf/npc/api/npc/Npc.kt`) [[1]](diffhunk://#diff-831b59b3101d4cf0752faa7acf80ace64fa7de14cc36f69fe29a71746935a66aR162-R169) and (`surf-npc-api/src/main/kotlin/dev/slne/surf/npc/api/SurfNpcApi.kt`) [[2]](diffhunk://#diff-8921ec879557f547e29181ae9c86a51fb3aae6be796ba4c7955205f24fe25c0cR236-R242).

### Bukkit Implementation:
* Implemented `playAnimation` in `BukkitNpc` to send animation packets to players based on visibility settings (`surf-npc-bukkit/src/main/kotlin/dev/slne/surf/npc/bukkit/npc/BukkitNpc.kt`).
* Added `createEntityAnimation` utility in `BukkitPackets` to map `NpcAnimationType` to Bukkit's animation packet types (`surf-npc-bukkit/src/main/kotlin/dev/slne/surf/npc/bukkit/BukkitPackets.kt`).
* Updated `BukkitNpcController` to delegate animation handling to the `Npc` object (`surf-npc-bukkit/src/main/kotlin/dev/slne/surf/npc/bukkit/controller/BukkitNpcController.kt`).

### Command System:
* Added `NpcAnimateCommand` to allow users to trigger animations via commands (`surf-npc-bukkit/src/main/kotlin/dev/slne/surf/npc/bukkit/command/sub/NpcAnimateCommand.kt`).
* Introduced `NpcAnimationTypeArgument` for parsing animation types in commands (`surf-npc-bukkit/src/main/kotlin/dev/slne/surf/npc/bukkit/command/argument/NpcAnimationTypeArgument.kt`).
* Registered the new `animate` subcommand in `NpcCommand` (`surf-npc-bukkit/src/main/kotlin/dev/slne/surf/npc/bukkit/command/NpcCommand.kt`).

### Permissions:
* Added `COMMAND_NPC_ANIMATE` permission to control access to the new animation command (`surf-npc-bukkit/src/main/kotlin/dev/slne/surf/npc/bukkit/util/PermissionRegistry.kt`).

resolves #7 