### PR TITLE
Feat/14 add owner ship to npcs with spawn reason

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
 kotlin.code.style=official
 kotlin.stdlib.default.dependency=false
 org.gradle.parallel=true
-version=1.21.7-1.3.1-SNAPSHOT
+version=1.21.7-1.4.0-SNAPSHOT

--- a/surf-npc-api/src/main/kotlin/dev/slne/surf/npc/api/SurfNpcApi.kt
+++ b/surf-npc-api/src/main/kotlin/dev/slne/surf/npc/api/SurfNpcApi.kt
@@ -1,6 +1,7 @@
 package dev.slne.surf.npc.api
 
 import dev.slne.surf.npc.api.npc.Npc
+import dev.slne.surf.npc.api.npc.NpcCreatorType
 import dev.slne.surf.npc.api.npc.animation.NpcAnimationType
 import dev.slne.surf.npc.api.npc.location.NpcLocation
 import dev.slne.surf.npc.api.npc.property.NpcProperty
@@ -17,6 +18,7 @@ import it.unimi.dsi.fastutil.objects.ObjectList
 import it.unimi.dsi.fastutil.objects.ObjectSet
 import net.kyori.adventure.text.Component
 import net.kyori.adventure.text.format.NamedTextColor
+import org.bukkit.plugin.java.JavaPlugin
 import java.util.*
 
 /**
@@ -49,7 +51,9 @@ interface SurfNpcApi {
         fixedRotation: NpcRotation? = null,
         persistent: Boolean = false,
         glowing: Boolean = false,
-        glowingColor: NamedTextColor = NamedTextColor.WHITE
+        glowingColor: NamedTextColor = NamedTextColor.WHITE,
+        plugin: JavaPlugin,
+        npcCreatorType: NpcCreatorType = NpcCreatorType.Plugin(plugin.name)
     ): NpcCreationResult
 
     /**

--- a/surf-npc-api/src/main/kotlin/dev/slne/surf/npc/api/dsl/NpcDslBuilder.kt
+++ b/surf-npc-api/src/main/kotlin/dev/slne/surf/npc/api/dsl/NpcDslBuilder.kt
@@ -9,6 +9,7 @@ import dev.slne.surf.npc.api.result.NpcCreationResult
 import dev.slne.surf.npc.api.surfNpcApi
 import dev.slne.surf.surfapi.core.api.messages.builder.SurfComponentBuilder
 import net.kyori.adventure.text.format.NamedTextColor
+import org.bukkit.plugin.java.JavaPlugin
 
 /**
  * Builder class for creating NPCs using a DSL.
@@ -145,10 +146,11 @@ suspend fun skin(name: String): NpcSkin {
 /**
  * Creates an NPC using a DSL block.
  *
+ * @param plugin The JavaPlugin instance for the NPC creation.
  * @param block The DSL block for configuring the NPC.
  * @return The result of the NPC creation.
  */
-fun npc(block: NpcDslBuilder.() -> Unit): NpcCreationResult {
+fun npc(plugin: JavaPlugin, block: NpcDslBuilder.() -> Unit): NpcCreationResult {
     val builder = NpcDslBuilder().apply(block)
     return surfNpcApi.createNpc(
         displayName = SurfComponentBuilder.builder().apply(builder.displayName).build(),
@@ -160,6 +162,7 @@ fun npc(block: NpcDslBuilder.() -> Unit): NpcCreationResult {
         fixedRotation = builder.fixedRotation,
         persistent = builder.persistent,
         glowing = builder.glowing,
-        glowingColor = builder.glowingColor
+        glowingColor = builder.glowingColor,
+        plugin = plugin
     )
 }

--- a/surf-npc-api/src/main/kotlin/dev/slne/surf/npc/api/npc/Npc.kt
+++ b/surf-npc-api/src/main/kotlin/dev/slne/surf/npc/api/npc/Npc.kt
@@ -117,6 +117,14 @@ interface Npc {
     fun isStatic() =
         properties.any { it.key == NpcProperty.Internal.PERSISTENCE && it.value.value as? Boolean ?: false }
 
+    /**
+     * Checks if the NPC is created by a plugin.
+     *
+     * @return True if the NPC is created by a plugin, false otherwise.
+     */
+    fun isFromPlugin() =
+        properties.any { it.key == NpcProperty.Internal.CREATOR_TYPE && it.value.value is NpcCreatorType.Plugin }
+
 
     /**
      * Adds properties to the NPC.

--- a/surf-npc-api/src/main/kotlin/dev/slne/surf/npc/api/npc/NpcCreatorType.kt
+++ b/surf-npc-api/src/main/kotlin/dev/slne/surf/npc/api/npc/NpcCreatorType.kt
@@ -1,0 +1,52 @@
+package dev.slne.surf.npc.api.npc
+
+/**
+ * Represents the type of an NPC creator.
+ */
+sealed class NpcCreatorType() {
+
+    /**
+     * Represents a player as the creator of the NPC.
+     *
+     * @property name The name of the player who created the NPC.
+     */
+    data class Player(val name: String) : NpcCreatorType()
+
+    /**
+     * Represents a plugin as the creator of the NPC.
+     *
+     * @property name The name of the plugin that created the NPC.
+     */
+    data class Plugin(val name: String) : NpcCreatorType()
+
+    /**
+     * Checks if the creator type is a player.
+     *
+     * @return `true` if the creator is a player, otherwise `false`.
+     */
+    fun isPlayer(): Boolean {
+        return this is Player
+    }
+
+    /**
+     * Checks if the creator type is a plugin.
+     *
+     * @return `true` if the creator is a plugin, otherwise `false`.
+     */
+    fun isPlugin(): Boolean {
+        return this is Plugin
+    }
+
+    /**
+     * Returns the name of the creator.
+     *
+     * @return The name of the creator, whether it's a player or a plugin.
+     */
+
+    fun name(): String {
+        return when (this) {
+            is Player -> name
+            is Plugin -> name
+        }
+    }
+}

--- a/surf-npc-api/src/main/kotlin/dev/slne/surf/npc/api/npc/property/NpcProperty.kt
+++ b/surf-npc-api/src/main/kotlin/dev/slne/surf/npc/api/npc/property/NpcProperty.kt
@@ -57,5 +57,10 @@ interface NpcProperty {
          * The color of the glowing effect for the NPC.
          */
         const val GLOWING_COLOR = "glowing_color"
+
+        /**
+         * The type of the creator of the NPC.
+         */
+        const val CREATOR_TYPE = "creator_type"
     }
 }

--- a/surf-npc-api/src/main/kotlin/dev/slne/surf/npc/api/npc/property/NpcPropertyType.kt
+++ b/surf-npc-api/src/main/kotlin/dev/slne/surf/npc/api/npc/property/NpcPropertyType.kt
@@ -88,5 +88,10 @@ interface NpcPropertyType {
          * Represents a skin data property type for an NPC.
          */
         const val SKIN_DATA = "skin_data"
+
+        /**
+         * The type of NPC creator.
+         */
+        const val NPC_CREATOR_TYPE = "npc_creator_type"
     }
 }

--- a/surf-npc-bukkit/src/main/kotlin/dev/slne/surf/npc/bukkit/BukkitMain.kt
+++ b/surf-npc-bukkit/src/main/kotlin/dev/slne/surf/npc/bukkit/BukkitMain.kt
@@ -33,6 +33,7 @@ class BukkitMain : SuspendingJavaPlugin() {
         propertyTypeRegistry.register(NamedTextColorPropertyType(NpcPropertyType.Types.NAMED_TEXT_COLOR))
         propertyTypeRegistry.register(NpcRotationPropertyType(NpcPropertyType.Types.NPC_ROTATION))
         propertyTypeRegistry.register(SkinDataPropertyType(NpcPropertyType.Types.SKIN_DATA))
+        propertyTypeRegistry.register(NpcCreatorTypePropertyType(NpcPropertyType.Types.NPC_CREATOR_TYPE))
 
         storageService.initialize()
         storageService.loadNpcs()

--- a/surf-npc-bukkit/src/main/kotlin/dev/slne/surf/npc/bukkit/api/BukkitSurfNpcApi.kt
+++ b/surf-npc-bukkit/src/main/kotlin/dev/slne/surf/npc/bukkit/api/BukkitSurfNpcApi.kt
@@ -3,6 +3,7 @@ package dev.slne.surf.npc.bukkit.api
 import com.google.auto.service.AutoService
 import dev.slne.surf.npc.api.SurfNpcApi
 import dev.slne.surf.npc.api.npc.Npc
+import dev.slne.surf.npc.api.npc.NpcCreatorType
 import dev.slne.surf.npc.api.npc.animation.NpcAnimationType
 import dev.slne.surf.npc.api.npc.location.NpcLocation
 import dev.slne.surf.npc.api.npc.property.NpcProperty
@@ -25,6 +26,7 @@ import it.unimi.dsi.fastutil.objects.ObjectSet
 import net.kyori.adventure.text.Component
 import net.kyori.adventure.text.format.NamedTextColor
 import net.kyori.adventure.util.Services
+import org.bukkit.plugin.java.JavaPlugin
 import java.util.*
 
 @AutoService(SurfNpcApi::class)
@@ -39,7 +41,9 @@ class BukkitSurfNpcApi : SurfNpcApi, Services.Fallback {
         fixedRotation: NpcRotation?,
         persistent: Boolean,
         glowing: Boolean,
-        glowingColor: NamedTextColor
+        glowingColor: NamedTextColor,
+        plugin: JavaPlugin,
+        npcCreatorType: NpcCreatorType
     ): NpcCreationResult {
         return npcController.createNpc(
             uniqueName,
@@ -51,7 +55,8 @@ class BukkitSurfNpcApi : SurfNpcApi, Services.Fallback {
             global,
             persistent,
             glowing,
-            glowingColor
+            glowingColor,
+            NpcCreatorType.Plugin(plugin.name)
         )
     }
 

--- a/surf-npc-bukkit/src/main/kotlin/dev/slne/surf/npc/bukkit/command/sub/NpcCreateCommand.kt
+++ b/surf-npc-bukkit/src/main/kotlin/dev/slne/surf/npc/bukkit/command/sub/NpcCreateCommand.kt
@@ -6,6 +6,7 @@ import dev.jorel.commandapi.kotlindsl.getValue
 import dev.jorel.commandapi.kotlindsl.playerExecutor
 import dev.jorel.commandapi.kotlindsl.stringArgument
 import dev.jorel.commandapi.kotlindsl.textArgument
+import dev.slne.surf.npc.api.npc.NpcCreatorType
 import dev.slne.surf.npc.api.npc.rotation.NpcRotationType
 import dev.slne.surf.npc.api.result.NpcCreationResult
 import dev.slne.surf.npc.bukkit.command.argument.rotationTypeArgument
@@ -31,6 +32,7 @@ class NpcCreateCommand(commandName: String) : CommandAPICommand(commandName) {
             val skin: String by args
             val rotationType: NpcRotationType by args
             val location = player.location
+            val createdBy = player.name
 
             if (!this.isValidName(name)) {
                 player.sendText {
@@ -57,7 +59,8 @@ class NpcCreateCommand(commandName: String) : CommandAPICommand(commandName) {
                     rotationType,
                     BukkitNpcRotation(location.yaw, location.pitch),
                     true,
-                    persistent = true
+                    persistent = true,
+                    npcCreatorType = NpcCreatorType.Player(createdBy)
                 )
 
                 if (npcResult.isFailure()) {

--- a/surf-npc-bukkit/src/main/kotlin/dev/slne/surf/npc/bukkit/command/sub/NpcDeleteCommand.kt
+++ b/surf-npc-bukkit/src/main/kotlin/dev/slne/surf/npc/bukkit/command/sub/NpcDeleteCommand.kt
@@ -17,6 +17,14 @@ class NpcDeleteCommand(commandName: String) : CommandAPICommand(commandName) {
         playerExecutor { player, args ->
             val npc: Npc by args
 
+            if (npc.isFromPlugin()) {
+                player.sendText {
+                    appendPrefix()
+                    error("Der Npc wurde von einem Plugin erstellt und kann daher nicht bearbeitet werden.")
+                }
+                return@playerExecutor
+            }
+
             npc.delete()
 
             if (npcController.getNpc(npc.id) == null) {

--- a/surf-npc-bukkit/src/main/kotlin/dev/slne/surf/npc/bukkit/command/sub/NpcInfoCommand.kt
+++ b/surf-npc-bukkit/src/main/kotlin/dev/slne/surf/npc/bukkit/command/sub/NpcInfoCommand.kt
@@ -42,7 +42,6 @@ class NpcInfoCommand(commandName: String) : CommandAPICommand(commandName) {
 
             val npcCreator =
                 npc.getPropertyValue(NpcProperty.Internal.CREATOR_TYPE, NpcCreatorType::class)
-                    ?: error("NPC ${npc.uniqueName} has no creator type set")
 
             player.sendText {
                 info("Npc Informationen".toSmallCaps(), TextDecoration.BOLD)
@@ -90,7 +89,7 @@ class NpcInfoCommand(commandName: String) : CommandAPICommand(commandName) {
                 append(CommonComponents.EM_DASH)
                 appendSpace()
                 variableKey("Ersteller: ")
-                variableValue(npcCreator.name())
+                variableValue(npcCreator?.name() ?: "Unbekannt")
 
                 append(CommonComponents.EM_DASH)
                 appendSpace()

--- a/surf-npc-bukkit/src/main/kotlin/dev/slne/surf/npc/bukkit/command/sub/NpcInfoCommand.kt
+++ b/surf-npc-bukkit/src/main/kotlin/dev/slne/surf/npc/bukkit/command/sub/NpcInfoCommand.kt
@@ -90,6 +90,7 @@ class NpcInfoCommand(commandName: String) : CommandAPICommand(commandName) {
                 appendSpace()
                 variableKey("Ersteller: ")
                 variableValue(npcCreator?.name() ?: "Unbekannt")
+                appendNewline()
 
                 append(CommonComponents.EM_DASH)
                 appendSpace()

--- a/surf-npc-bukkit/src/main/kotlin/dev/slne/surf/npc/bukkit/command/sub/NpcInfoCommand.kt
+++ b/surf-npc-bukkit/src/main/kotlin/dev/slne/surf/npc/bukkit/command/sub/NpcInfoCommand.kt
@@ -4,6 +4,7 @@ import dev.jorel.commandapi.CommandAPICommand
 import dev.jorel.commandapi.kotlindsl.getValue
 import dev.jorel.commandapi.kotlindsl.playerExecutor
 import dev.slne.surf.npc.api.npc.Npc
+import dev.slne.surf.npc.api.npc.NpcCreatorType
 import dev.slne.surf.npc.api.npc.location.NpcLocation
 import dev.slne.surf.npc.api.npc.property.NpcProperty
 import dev.slne.surf.npc.api.npc.skin.NpcSkin
@@ -11,6 +12,7 @@ import dev.slne.surf.npc.bukkit.command.argument.npcArgument
 import dev.slne.surf.npc.bukkit.util.PermissionRegistry
 import dev.slne.surf.npc.bukkit.util.readableString
 import dev.slne.surf.surfapi.core.api.font.toSmallCaps
+import dev.slne.surf.surfapi.core.api.messages.CommonComponents
 import dev.slne.surf.surfapi.core.api.messages.adventure.clickRunsCommand
 import dev.slne.surf.surfapi.core.api.messages.adventure.sendText
 import net.kyori.adventure.text.Component
@@ -38,57 +40,46 @@ class NpcInfoCommand(commandName: String) : CommandAPICommand(commandName) {
                 npc.getPropertyValue(NpcProperty.Internal.VISIBILITY_GLOBAL, Boolean::class)
                     ?: error("NPC ${npc.uniqueName} has no global visibility set")
 
+            val npcCreator =
+                npc.getPropertyValue(NpcProperty.Internal.CREATOR_TYPE, NpcCreatorType::class)
+                    ?: error("NPC ${npc.uniqueName} has no creator type set")
+
             player.sendText {
-                append {
-                    info("Npc Informationen".toSmallCaps())
-                    decorate(TextDecoration.BOLD)
-                }
+                info("Npc Informationen".toSmallCaps(), TextDecoration.BOLD)
                 appendNewline()
 
-                append {
-                    info("| ")
-                    decorate(TextDecoration.BOLD)
-                }
+                append(CommonComponents.EM_DASH)
+                appendSpace()
                 variableKey("Name: ")
                 variableValue(npc.uniqueName)
                 appendNewline()
 
-                append {
-                    info("| ")
-                    decorate(TextDecoration.BOLD)
-                }
+                append(CommonComponents.EM_DASH)
+                appendSpace()
                 variableKey("Anzeigename: ")
                 append(displayName)
                 appendNewline()
 
-                append {
-                    info("| ")
-                    decorate(TextDecoration.BOLD)
-                }
+                append(CommonComponents.EM_DASH)
+                appendSpace()
                 variableKey("ID: ")
                 variableValue(npc.id)
                 appendNewline()
 
-                append {
-                    info("| ")
-                    decorate(TextDecoration.BOLD)
-                }
+                append(CommonComponents.EM_DASH)
+                appendSpace()
                 variableKey("Nametag-ID: ")
                 variableValue(npc.nameTagId)
                 appendNewline()
 
-                append {
-                    info("| ")
-                    decorate(TextDecoration.BOLD)
-                }
+                append(CommonComponents.EM_DASH)
+                appendSpace()
                 variableKey("Uuid: ")
                 variableValue(npc.npcUuid.toString())
                 appendNewline()
 
-                append {
-                    info("| ")
-                    decorate(TextDecoration.BOLD)
-                }
+                append(CommonComponents.EM_DASH)
+                appendSpace()
                 append {
                     variableKey("Ort: ")
                     variableValue(location.readableString())
@@ -96,26 +87,25 @@ class NpcInfoCommand(commandName: String) : CommandAPICommand(commandName) {
                 }
                 appendNewline()
 
-                append {
-                    info("| ")
-                    decorate(TextDecoration.BOLD)
-                }
+                append(CommonComponents.EM_DASH)
+                appendSpace()
+                variableKey("Ersteller: ")
+                variableValue(npcCreator.name())
+
+                append(CommonComponents.EM_DASH)
+                appendSpace()
                 variableKey("Rotation: ")
                 variableValue(if (rotationType) "Per-Player" else "Fixed")
                 appendNewline()
 
-                append {
-                    info("| ")
-                    decorate(TextDecoration.BOLD)
-                }
+                append(CommonComponents.EM_DASH)
+                appendSpace()
                 variableKey("Skin: ")
                 variableValue(skinData.ownerName)
                 appendNewline()
 
-                append {
-                    info("| ")
-                    decorate(TextDecoration.BOLD)
-                }
+                append(CommonComponents.EM_DASH)
+                appendSpace()
                 variableKey("Global: ")
                 variableValue(if (global) "Ja" else "Nein")
             }

--- a/surf-npc-bukkit/src/main/kotlin/dev/slne/surf/npc/bukkit/command/sub/NpcTeleportHereCommand.kt
+++ b/surf-npc-bukkit/src/main/kotlin/dev/slne/surf/npc/bukkit/command/sub/NpcTeleportHereCommand.kt
@@ -19,6 +19,15 @@ class NpcTeleportHereCommand(commandName: String) : CommandAPICommand(commandNam
         playerExecutor { player, args ->
             val npc: Npc by args
             val target: Player? by args
+
+            if (npc.isFromPlugin()) {
+                player.sendText {
+                    appendPrefix()
+                    error("Der Npc wurde von einem Plugin erstellt und kann daher nicht bearbeitet werden.")
+                }
+                return@playerExecutor
+            }
+
             if (target != null) {
                 val targetPlayer = target ?: return@playerExecutor run {
                     player.sendText {

--- a/surf-npc-bukkit/src/main/kotlin/dev/slne/surf/npc/bukkit/command/sub/edit/NpcEditDisplayNameCommand.kt
+++ b/surf-npc-bukkit/src/main/kotlin/dev/slne/surf/npc/bukkit/command/sub/edit/NpcEditDisplayNameCommand.kt
@@ -25,6 +25,14 @@ class NpcEditDisplayNameCommand(commandName: String) : CommandAPICommand(command
 
             val name = miniMessage.deserialize(displayName)
 
+            if (npc.isFromPlugin()) {
+                player.sendText {
+                    appendPrefix()
+                    error("Der Npc wurde von einem Plugin erstellt und kann daher nicht bearbeitet werden.")
+                }
+                return@playerExecutor
+            }
+
             npc.addProperty(
                 BukkitNpcProperty(
                     NpcProperty.Internal.DISPLAYNAME,

--- a/surf-npc-bukkit/src/main/kotlin/dev/slne/surf/npc/bukkit/command/sub/edit/NpcEditRotationCommand.kt
+++ b/surf-npc-bukkit/src/main/kotlin/dev/slne/surf/npc/bukkit/command/sub/edit/NpcEditRotationCommand.kt
@@ -24,6 +24,14 @@ class NpcEditRotationCommand(commandName: String) : CommandAPICommand(commandNam
             val npc: Npc by args
             val rotationType: NpcRotationType by args
 
+            if (npc.isFromPlugin()) {
+                player.sendText {
+                    appendPrefix()
+                    error("Der Npc wurde von einem Plugin erstellt und kann daher nicht bearbeitet werden.")
+                }
+                return@playerExecutor
+            }
+
             npc.addProperty(
                 BukkitNpcProperty(
                     NpcProperty.Internal.ROTATION_TYPE,

--- a/surf-npc-bukkit/src/main/kotlin/dev/slne/surf/npc/bukkit/command/sub/edit/NpcEditSkinCommand.kt
+++ b/surf-npc-bukkit/src/main/kotlin/dev/slne/surf/npc/bukkit/command/sub/edit/NpcEditSkinCommand.kt
@@ -25,6 +25,14 @@ class NpcEditSkinCommand(commandName: String) : CommandAPICommand(commandName) {
             val npc: Npc by args
             val skinPlayer: String by args
 
+            if (npc.isFromPlugin()) {
+                player.sendText {
+                    appendPrefix()
+                    error("Der Npc wurde von einem Plugin erstellt und kann daher nicht bearbeitet werden.")
+                }
+                return@playerExecutor
+            }
+
             player.sendText {
                 appendPrefix()
                 info("Die Skin-Daten für den Spieler ")

--- a/surf-npc-bukkit/src/main/kotlin/dev/slne/surf/npc/bukkit/command/sub/property/NpcPropertyAddCommand.kt
+++ b/surf-npc-bukkit/src/main/kotlin/dev/slne/surf/npc/bukkit/command/sub/property/NpcPropertyAddCommand.kt
@@ -25,6 +25,14 @@ class NpcPropertyAddCommand(commandName: String) : CommandAPICommand(commandName
             val value: String by args
             val propertyType: NpcPropertyType by args
 
+            if (npc.isFromPlugin()) {
+                player.sendText {
+                    appendPrefix()
+                    error("Der Npc wurde von einem Plugin erstellt und kann daher nicht bearbeitet werden.")
+                }
+                return@playerExecutor
+            }
+
             val exists = npc.hasProperty(key)
 
             npc.addProperty(

--- a/surf-npc-bukkit/src/main/kotlin/dev/slne/surf/npc/bukkit/command/sub/property/NpcPropertyRemoveCommand.kt
+++ b/surf-npc-bukkit/src/main/kotlin/dev/slne/surf/npc/bukkit/command/sub/property/NpcPropertyRemoveCommand.kt
@@ -19,6 +19,14 @@ class NpcPropertyRemoveCommand(commandName: String) : CommandAPICommand(commandN
             val npc: Npc by args
             val key: String by args
 
+            if (npc.isFromPlugin()) {
+                player.sendText {
+                    appendPrefix()
+                    error("Der Npc wurde von einem Plugin erstellt und kann daher nicht bearbeitet werden.")
+                }
+                return@playerExecutor
+            }
+
             if (!npc.hasProperty(key)) {
                 player.sendText {
                     appendPrefix()

--- a/surf-npc-bukkit/src/main/kotlin/dev/slne/surf/npc/bukkit/controller/BukkitNpcController.kt
+++ b/surf-npc-bukkit/src/main/kotlin/dev/slne/surf/npc/bukkit/controller/BukkitNpcController.kt
@@ -6,6 +6,7 @@ import com.google.auto.service.AutoService
 import dev.slne.surf.npc.api.event.NpcCreateEvent
 import dev.slne.surf.npc.api.event.NpcDeleteEvent
 import dev.slne.surf.npc.api.npc.Npc
+import dev.slne.surf.npc.api.npc.NpcCreatorType
 import dev.slne.surf.npc.api.npc.animation.NpcAnimationType
 import dev.slne.surf.npc.api.npc.location.NpcLocation
 import dev.slne.surf.npc.api.npc.property.NpcProperty
@@ -42,7 +43,8 @@ class BukkitNpcController : NpcController, Services.Fallback {
         global: Boolean,
         persistent: Boolean,
         glowing: Boolean,
-        glowingColor: NamedTextColor
+        glowingColor: NamedTextColor,
+        npcCreatorType: NpcCreatorType
     ): NpcCreationResult {
         val id = random.nextInt()
         val nameTagId = random.nextInt()
@@ -87,6 +89,9 @@ class BukkitNpcController : NpcController, Services.Fallback {
         val skinDataType = propertyTypeRegistry.get(
             NpcPropertyType.Types.SKIN_DATA
         ) ?: error("SKIN_DATA property type not found")
+        val npcCreatorPropertyType = propertyTypeRegistry.get(
+            NpcPropertyType.Types.NPC_CREATOR_TYPE
+        ) ?: error("NPC_CREATOR_TYPE property type not found")
 
         npc.addProperties(
             Triple(
@@ -117,6 +122,9 @@ class BukkitNpcController : NpcController, Services.Fallback {
             ),
             Triple(
                 NpcProperty.Internal.GLOWING_COLOR, glowingColor, namedTextColorType
+            ),
+            Triple(
+                NpcProperty.Internal.CREATOR_TYPE, npcCreatorType, npcCreatorPropertyType
             )
         )
 

--- a/surf-npc-bukkit/src/main/kotlin/dev/slne/surf/npc/bukkit/npc/property/impl/NpcCreatorTypePropertyType.kt
+++ b/surf-npc-bukkit/src/main/kotlin/dev/slne/surf/npc/bukkit/npc/property/impl/NpcCreatorTypePropertyType.kt
@@ -1,0 +1,24 @@
+package dev.slne.surf.npc.bukkit.npc.property.impl
+
+import dev.slne.surf.npc.api.npc.NpcCreatorType
+import dev.slne.surf.npc.api.npc.property.NpcPropertyType
+
+class NpcCreatorTypePropertyType(override val id: String) : NpcPropertyType {
+    override fun encode(value: Any): String {
+        require(value is NpcCreatorType) { "Expected NpcCreatorType, got ${value::class}" }
+        return "${if (value.isPlayer()) "player" else "plugin"}:${value.name()}"
+    }
+
+    override fun decode(value: String): NpcCreatorType {
+        val parts = value.split(":")
+        require(parts.size == 2) { "Invalid creator type format: $value" }
+
+        return when (parts[0]) {
+            "player" -> NpcCreatorType.Player(parts[1])
+            "plugin" -> NpcCreatorType.Plugin(parts[1])
+            else -> throw IllegalArgumentException("Unknown creator type: ${parts[0]}")
+        }
+    }
+}
+
+

--- a/surf-npc-core/src/main/kotlin/dev/slne/surf/npc/core/controller/NpcController.kt
+++ b/surf-npc-core/src/main/kotlin/dev/slne/surf/npc/core/controller/NpcController.kt
@@ -1,6 +1,7 @@
 package dev.slne.surf.npc.core.controller
 
 import dev.slne.surf.npc.api.npc.Npc
+import dev.slne.surf.npc.api.npc.NpcCreatorType
 import dev.slne.surf.npc.api.npc.animation.NpcAnimationType
 import dev.slne.surf.npc.api.npc.location.NpcLocation
 import dev.slne.surf.npc.api.npc.property.NpcProperty
@@ -45,7 +46,8 @@ interface NpcController {
         global: Boolean,
         persistent: Boolean = false,
         glowing: Boolean = false,
-        glowingColor: NamedTextColor = NamedTextColor.WHITE
+        glowingColor: NamedTextColor = NamedTextColor.WHITE,
+        npcCreatorType: NpcCreatorType
     ): NpcCreationResult
 
     /**

--- a/surf-npc-example-dsl/src/main/kotlin/dev/slne/surf/npc/example/SurfNpcExamplePlugin.kt
+++ b/surf-npc-example-dsl/src/main/kotlin/dev/slne/surf/npc/example/SurfNpcExamplePlugin.kt
@@ -21,7 +21,7 @@ class SurfNpcExamplePlugin() : SuspendingJavaPlugin() {
         /**
          * Creates an example NPC using the DSL provided by the Surf-NPC API.
          */
-        npc {
+        npc(this) {
             displayName = {
                 append(
                     MiniMessage.miniMessage()
@@ -52,7 +52,8 @@ class SurfNpcExamplePlugin() : SuspendingJavaPlugin() {
             }
             global = true
             rotationType = NpcRotationType.PER_PLAYER
-            persistent = false // This is already the default value, but can be set explicitly if needed.
+            persistent =
+                false // This is already the default value, but can be set explicitly if needed.
             glowing = true
             glowingColor = NamedTextColor.RED
         }

--- a/surf-npc-example/src/main/kotlin/dev/slne/surf/npc/example/SurfNpcExamplePlugin.kt
+++ b/surf-npc-example/src/main/kotlin/dev/slne/surf/npc/example/SurfNpcExamplePlugin.kt
@@ -17,7 +17,8 @@ class SurfNpcExamplePlugin() : SuspendingJavaPlugin() {
             MiniMessage.miniMessage().deserialize("<rainbow>Example Npc by surf-npc-example"),
             "example_npc",
             createSkinData(),
-            surfNpcApi.createLocation(0.0, 0.0, 0.0, "world")
+            surfNpcApi.createLocation(0.0, 0.0, 0.0, "world"),
+            plugin = this
         )
 
         val npc = surfNpcApi.getNpc("example_npc") ?: return run {


### PR DESCRIPTION
This pull request introduces a new concept for tracking the creator type of NPCs (either a player or a plugin) and enforces restrictions on editing or deleting NPCs created by plugins. It also enhances NPC creation APIs and commands to support this new functionality, and updates property registries and info commands to display the creator information.

### Creator Type Tracking & Enforcement

* Introduced the sealed class `NpcCreatorType` to represent whether an NPC was created by a player or a plugin, including helper methods for type checking and retrieving the creator's name. (`surf-npc-api/src/main/kotlin/dev/slne/surf/npc/api/npc/NpcCreatorType.kt`)
* Added new internal property keys (`CREATOR_TYPE`, `NPC_CREATOR_TYPE`) to track the creator type in NPC properties. (`surf-npc-api/src/main/kotlin/dev/slne/surf/npc/api/npc/property/NpcProperty.kt`, `surf-npc-api/src/main/kotlin/dev/slne/surf/npc/api/npc/property/NpcPropertyType.kt`) [[1]](diffhunk://#diff-69c3e8620e25c46bbd64714858e14d5960044f31b1ee0f3d75a1e6347134f60aR60-R64) [[2]](diffhunk://#diff-05537b97c82d4ba6ff88855dc32fc77d65d91c706565ddb815cbfb41c674dadeR91-R95)
* Registered the new property type in the Bukkit plugin initialization. (`surf-npc-bukkit/src/main/kotlin/dev/slne/surf/npc/bukkit/BukkitMain.kt`)

### API & Command Changes

* Updated the NPC creation API (`SurfNpcApi`) and DSL to require the plugin instance and support specifying the creator type, defaulting to plugin-based creation. (`surf-npc-api/src/main/kotlin/dev/slne/surf/npc/api/SurfNpcApi.kt`, `surf-npc-api/src/main/kotlin/dev/slne/surf/npc/api/dsl/NpcDslBuilder.kt`, `surf-npc-bukkit/src/main/kotlin/dev/slne/surf/npc/bukkit/api/BukkitSurfNpcApi.kt`) [[1]](diffhunk://#diff-8921ec879557f547e29181ae9c86a51fb3aae6be796ba4c7955205f24fe25c0cL52-R56) [[2]](diffhunk://#diff-4a0b84065fd341541aa206c5300e7068af1865a6b1efe6277490774740b55bc5R149-R153) [[3]](diffhunk://#diff-0b9a6128864f6e5aac77465bd23ccfb0a76f71d18f2dcdcfb1f06c23fbafc8baL42-R46)
* Updated the NPC creation command to set the creator type to `Player` when a player creates an NPC. (`surf-npc-bukkit/src/main/kotlin/dev/slne/surf/npc/bukkit/command/sub/NpcCreateCommand.kt`)

### Editing & Deletion Restrictions

* Added checks to prevent editing or deleting NPCs created by plugins in all relevant commands (`delete`, `teleport`, `edit display name`, `edit rotation`, `edit skin`). Users attempting these actions receive an error message. (`surf-npc-bukkit/src/main/kotlin/dev/slne/surf/npc/bukkit/command/sub/NpcDeleteCommand.kt`, `surf-npc-bukkit/src/main/kotlin/dev/slne/surf/npc/bukkit/command/sub/NpcTeleportHereCommand.kt`, `surf-npc-bukkit/src/main/kotlin/dev/slne/surf/npc/bukkit/command/sub/edit/NpcEditDisplayNameCommand.kt`, `surf-npc-bukkit/src/main/kotlin/dev/slne/surf/npc/bukkit/command/sub/edit/NpcEditRotationCommand.kt`, `surf-npc-bukkit/src/main/kotlin/dev/slne/surf/npc/bukkit/command/sub/edit/NpcEditSkinCommand.kt`) [[1]](diffhunk://#diff-7f8e7686e5760f98f8ee70e8d3eb7cdb5e093fc637da03c81e5de13941424ccbR20-R27) [[2]](diffhunk://#diff-51b6ba50eda7fc4e6378be58ae77109b746b1cfd0852d142244a6e1275f7774fR22-R30) [[3]](diffhunk://#diff-9a6d39203f97ae4d2c64f457a439dac1dabb372cdc1de6173ed7ea2de59d3df4R28-R35) [[4]](diffhunk://#diff-d25f932ee3b2a0f1d8ccd6de8af321d4f205c3c8486f89f16b3cb296d288a179R27-R34) [[5]](diffhunk://#diff-c8fde52acc0651fcdc913ca4081c659c127ebdd15e7d5a15954ceff2869c7c47R28-R35)
* Added the `isFromPlugin()` method to the `Npc` interface for checking the creator type. (`surf-npc-api/src/main/kotlin/dev/slne/surf/npc/api/npc/Npc.kt`)

### Info Command Enhancement

* Updated the NPC info command to display the creator's name (player or plugin) in the output, using the new property and helper methods. (`surf-npc-bukkit/src/main/kotlin/dev/slne/surf/npc/bukkit/command/sub/NpcInfoCommand.kt`)

These changes collectively improve traceability of NPC origins and ensure server integrity by restricting modification of plugin-created NPCs.

resolves #14 