### PR TITLE
feat: add WorldChangeListener to handle NPC respawning on world change

### DIFF
--- a/surf-npc-bukkit/src/main/kotlin/dev/slne/surf/npc/bukkit/BukkitMain.kt
+++ b/surf-npc-bukkit/src/main/kotlin/dev/slne/surf/npc/bukkit/BukkitMain.kt
@@ -7,10 +7,11 @@ import dev.slne.surf.npc.api.npc.property.NpcPropertyType
 import dev.slne.surf.npc.bukkit.command.NpcCommand
 import dev.slne.surf.npc.bukkit.listener.ConnectionListener
 import dev.slne.surf.npc.bukkit.listener.NpcListener
+import dev.slne.surf.npc.bukkit.listener.WorldChangeListener
 import dev.slne.surf.npc.bukkit.npc.property.impl.*
 import dev.slne.surf.npc.core.property.propertyTypeRegistry
 import dev.slne.surf.npc.core.service.storageService
-import org.bukkit.Bukkit
+import dev.slne.surf.surfapi.bukkit.api.event.register
 import org.bukkit.plugin.java.JavaPlugin
 
 class BukkitMain : SuspendingJavaPlugin() {
@@ -19,7 +20,8 @@ class BukkitMain : SuspendingJavaPlugin() {
             NpcListener(),
             PacketListenerPriority.NORMAL
         )
-        Bukkit.getPluginManager().registerEvents(ConnectionListener(), this)
+        ConnectionListener().register()
+        WorldChangeListener().register()
 
         propertyTypeRegistry.register(BooleanPropertyType(NpcPropertyType.Types.BOOLEAN))
         propertyTypeRegistry.register(ComponentPropertyType(NpcPropertyType.Types.COMPONENT))

--- a/surf-npc-bukkit/src/main/kotlin/dev/slne/surf/npc/bukkit/controller/BukkitNpcController.kt
+++ b/surf-npc-bukkit/src/main/kotlin/dev/slne/surf/npc/bukkit/controller/BukkitNpcController.kt
@@ -221,10 +221,6 @@ class BukkitNpcController : NpcController, Services.Fallback {
             return NpcRespawnResult.Failure(NpcRespawnFailureReason.NOT_EXIST)
         }
 
-        if (npc.viewers.contains(uuid)) {
-            return NpcRespawnResult.Failure(NpcRespawnFailureReason.ALREADY_SPAWNED)
-        }
-
         npc.despawn(uuid)
         npc.spawn(uuid)
 

--- a/surf-npc-bukkit/src/main/kotlin/dev/slne/surf/npc/bukkit/listener/WorldChangeListener.kt
+++ b/surf-npc-bukkit/src/main/kotlin/dev/slne/surf/npc/bukkit/listener/WorldChangeListener.kt
@@ -1,0 +1,26 @@
+package dev.slne.surf.npc.bukkit.listener
+
+import dev.slne.surf.npc.api.npc.location.NpcLocation
+import dev.slne.surf.npc.api.npc.property.NpcProperty
+import dev.slne.surf.npc.core.controller.npcController
+import org.bukkit.event.EventHandler
+import org.bukkit.event.Listener
+import org.bukkit.event.player.PlayerChangedWorldEvent
+
+class WorldChangeListener : Listener {
+    @EventHandler
+    fun onWorldChanged(event: PlayerChangedWorldEvent) {
+        val player = event.player
+        val world = player.world
+
+        npcController.getNpcs().forEach {
+            val npcLocation = it.getPropertyValue(NpcProperty.Internal.LOCATION, NpcLocation::class)
+                ?: return@forEach
+            val npcWorldName = npcLocation.world
+
+            if (npcWorldName == world.name) {
+                npcController.reShowNpc(it, player.uniqueId)
+            }
+        }
+    }
+}

--- a/surf-npc-bukkit/src/main/kotlin/dev/slne/surf/npc/bukkit/listener/WorldChangeListener.kt
+++ b/surf-npc-bukkit/src/main/kotlin/dev/slne/surf/npc/bukkit/listener/WorldChangeListener.kt
@@ -13,21 +13,11 @@ class WorldChangeListener : Listener {
         val player = event.player
         val world = player.world
 
-        npcController.getNpcs().forEach {
+        npcController.getNpcs().mapNotNull {
             val npcLocation = it.getPropertyValue(NpcProperty.Internal.LOCATION, NpcLocation::class)
-                ?: return@forEach
-            val npcWorldName = npcLocation.world
-
-            if (npcWorldName == world.name) {
-                npcController.reShowNpc(it, player.uniqueId)
-            }
-        npcController.getNpcs()
-            .mapNotNull { npc ->
-                val npcLocation = npc.getPropertyValue(NpcProperty.Internal.LOCATION, NpcLocation::class)
-                if (npcLocation?.world == world.name) npc to npcLocation else null
-            }
-            .forEach { (npc, _) ->
-                npcController.reShowNpc(npc, player.uniqueId)
-            }
+            if (npcLocation?.world == world.name) it to npcLocation else null
+        }.forEach { (npc, _) ->
+            npcController.reShowNpc(npc, player.uniqueId)
+        }
     }
 }

--- a/surf-npc-bukkit/src/main/kotlin/dev/slne/surf/npc/bukkit/listener/WorldChangeListener.kt
+++ b/surf-npc-bukkit/src/main/kotlin/dev/slne/surf/npc/bukkit/listener/WorldChangeListener.kt
@@ -21,6 +21,13 @@ class WorldChangeListener : Listener {
             if (npcWorldName == world.name) {
                 npcController.reShowNpc(it, player.uniqueId)
             }
-        }
+        npcController.getNpcs()
+            .mapNotNull { npc ->
+                val npcLocation = npc.getPropertyValue(NpcProperty.Internal.LOCATION, NpcLocation::class)
+                if (npcLocation?.world == world.name) npc to npcLocation else null
+            }
+            .forEach { (npc, _) ->
+                npcController.reShowNpc(npc, player.uniqueId)
+            }
     }
 }


### PR DESCRIPTION
This pull request introduces a new listener to handle NPC visibility when players change worlds and refines the NPC respawn logic. The main changes are the addition of the `WorldChangeListener` and updates to event registration and respawn behavior.

**Event Listener Improvements:**

* Added a new `WorldChangeListener` class that listens for `PlayerChangedWorldEvent` and ensures NPCs in the new world are properly shown to the player. (`surf-npc-bukkit/src/main/kotlin/dev/slne/surf/npc/bukkit/listener/WorldChangeListener.kt`)
* Updated `BukkitMain` to register the new `WorldChangeListener` and refactored the registration of `ConnectionListener` to use a `register()` extension method. (`surf-npc-bukkit/src/main/kotlin/dev/slne/surf/npc/bukkit/BukkitMain.kt`) [[1]](diffhunk://#diff-17beeae24d328bd6ae1b7851b3752a2752e70de665c19e72b5e4fcfd06c6d7dfR10-R14) [[2]](diffhunk://#diff-17beeae24d328bd6ae1b7851b3752a2752e70de665c19e72b5e4fcfd06c6d7dfL22-R24)

**NPC Respawn Logic:**

* Removed the check that prevented respawning an NPC for a player if it was already spawned, ensuring that despawn and spawn are always called during a respawn request. (`surf-npc-bukkit/src/main/kotlin/dev/slne/surf/npc/bukkit/controller/BukkitNpcController.kt`)