### PR TITLE
fix: rename NpcCreatorType.Player to NpcCreatorType.Client

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
 kotlin.code.style=official
 kotlin.stdlib.default.dependency=false
 org.gradle.parallel=true
-version=1.21.7-1.4.1-SNAPSHOT
+version=1.21.7-1.4.2-SNAPSHOT

--- a/surf-npc-api/src/main/kotlin/dev/slne/surf/npc/api/npc/NpcCreatorType.kt
+++ b/surf-npc-api/src/main/kotlin/dev/slne/surf/npc/api/npc/NpcCreatorType.kt
@@ -10,7 +10,7 @@ sealed class NpcCreatorType() {
      *
      * @property name The name of the player who created the NPC.
      */
-    data class Player(val name: String) : NpcCreatorType()
+    data class Client(val name: String) : NpcCreatorType()
 
     /**
      * Represents a plugin as the creator of the NPC.
@@ -24,8 +24,8 @@ sealed class NpcCreatorType() {
      *
      * @return `true` if the creator is a player, otherwise `false`.
      */
-    fun isPlayer(): Boolean {
-        return this is Player
+    fun isClient(): Boolean {
+        return this is Client
     }
 
     /**
@@ -45,7 +45,7 @@ sealed class NpcCreatorType() {
 
     fun name(): String {
         return when (this) {
-            is Player -> name
+            is Client -> name
             is Plugin -> name
         }
     }

--- a/surf-npc-bukkit/src/main/kotlin/dev/slne/surf/npc/bukkit/command/sub/NpcCreateCommand.kt
+++ b/surf-npc-bukkit/src/main/kotlin/dev/slne/surf/npc/bukkit/command/sub/NpcCreateCommand.kt
@@ -60,7 +60,7 @@ class NpcCreateCommand(commandName: String) : CommandAPICommand(commandName) {
                     BukkitNpcRotation(location.yaw, location.pitch),
                     true,
                     persistent = true,
-                    npcCreatorType = NpcCreatorType.Player(createdBy)
+                    npcCreatorType = NpcCreatorType.Client(createdBy)
                 )
 
                 if (npcResult.isFailure()) {

--- a/surf-npc-bukkit/src/main/kotlin/dev/slne/surf/npc/bukkit/npc/property/impl/NpcCreatorTypePropertyType.kt
+++ b/surf-npc-bukkit/src/main/kotlin/dev/slne/surf/npc/bukkit/npc/property/impl/NpcCreatorTypePropertyType.kt
@@ -6,7 +6,7 @@ import dev.slne.surf.npc.api.npc.property.NpcPropertyType
 class NpcCreatorTypePropertyType(override val id: String) : NpcPropertyType {
     override fun encode(value: Any): String {
         require(value is NpcCreatorType) { "Expected NpcCreatorType, got ${value::class}" }
-        return "${if (value.isPlayer()) "player" else "plugin"}:${value.name()}"
+        return "${if (value.isClient()) "player" else "plugin"}:${value.name()}"
     }
 
     override fun decode(value: String): NpcCreatorType {
@@ -14,7 +14,7 @@ class NpcCreatorTypePropertyType(override val id: String) : NpcPropertyType {
         require(parts.size == 2) { "Invalid creator type format: $value" }
 
         return when (parts[0]) {
-            "player" -> NpcCreatorType.Player(parts[1])
+            "player" -> NpcCreatorType.Client(parts[1])
             "plugin" -> NpcCreatorType.Plugin(parts[1])
             else -> throw IllegalArgumentException("Unknown creator type: ${parts[0]}")
         }


### PR DESCRIPTION
This pull request refactors the way NPC creators are represented in the codebase, replacing the `Player` type with `Client` in the `NpcCreatorType` sealed class and updating all related usages. This change clarifies the role of the creator and ensures naming consistency throughout the code. Additionally, the project version is incremented to reflect these changes.

### Refactor NPC Creator Representation

* Renamed `NpcCreatorType.Player` to `NpcCreatorType.Client` and updated all references, including the type check method from `isPlayer()` to `isClient()`, and usage in the `name()` method. [[1]](diffhunk://#diff-4ee693b4b557aa7879e10fd83feba58528bd2724d8bd16d0db5ff889446545deL13-R13) [[2]](diffhunk://#diff-4ee693b4b557aa7879e10fd83feba58528bd2724d8bd16d0db5ff889446545deL27-R28) [[3]](diffhunk://#diff-4ee693b4b557aa7879e10fd83feba58528bd2724d8bd16d0db5ff889446545deL48-R48)
* Updated the creation of NPCs in `NpcCreateCommand` to use `NpcCreatorType.Client` instead of `NpcCreatorType.Player`.
* Modified the encoding and decoding logic in `NpcCreatorTypePropertyType` to use `Client` for the "player" type, ensuring serialization and deserialization remain consistent with the new naming.

### Version Update

* Bumped project version from `1.21.7-1.4.1-SNAPSHOT` to `1.21.7-1.4.2-SNAPSHOT` in `gradle.properties`.