### PR TITLE
Feat/bstats

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
 kotlin.code.style=official
 kotlin.stdlib.default.dependency=false
 org.gradle.parallel=true
-version=1.21.7-1.4.2-SNAPSHOT
+version=1.21.7-1.4.3-SNAPSHOT

--- a/surf-npc-bukkit/src/main/kotlin/dev/slne/surf/npc/bukkit/BukkitMain.kt
+++ b/surf-npc-bukkit/src/main/kotlin/dev/slne/surf/npc/bukkit/BukkitMain.kt
@@ -16,7 +16,7 @@ import dev.slne.surf.surfapi.bukkit.api.metrics.Metrics
 import org.bukkit.plugin.java.JavaPlugin
 
 class BukkitMain : SuspendingJavaPlugin() {
-    lateinit var metrics: Metrics
+    private lateinit var metrics: Metrics
 
     override fun onEnable() {
         PacketEvents.getAPI().eventManager.registerListener(

--- a/surf-npc-bukkit/src/main/kotlin/dev/slne/surf/npc/bukkit/BukkitMain.kt
+++ b/surf-npc-bukkit/src/main/kotlin/dev/slne/surf/npc/bukkit/BukkitMain.kt
@@ -12,9 +12,12 @@ import dev.slne.surf.npc.bukkit.npc.property.impl.*
 import dev.slne.surf.npc.core.property.propertyTypeRegistry
 import dev.slne.surf.npc.core.service.storageService
 import dev.slne.surf.surfapi.bukkit.api.event.register
+import dev.slne.surf.surfapi.bukkit.api.metrics.Metrics
 import org.bukkit.plugin.java.JavaPlugin
 
 class BukkitMain : SuspendingJavaPlugin() {
+    lateinit var metrics: Metrics
+
     override fun onEnable() {
         PacketEvents.getAPI().eventManager.registerListener(
             NpcListener(),
@@ -22,6 +25,8 @@ class BukkitMain : SuspendingJavaPlugin() {
         )
         ConnectionListener().register()
         WorldChangeListener().register()
+
+        metrics = Metrics(this, 27049)
 
         propertyTypeRegistry.register(BooleanPropertyType(NpcPropertyType.Types.BOOLEAN))
         propertyTypeRegistry.register(ComponentPropertyType(NpcPropertyType.Types.COMPONENT))
@@ -44,6 +49,10 @@ class BukkitMain : SuspendingJavaPlugin() {
     }
 
     override fun onDisable() {
+        if (::metrics.isInitialized) {
+            metrics.shutdown()
+        }
+
         storageService.saveNpcs()
     }
 }


### PR DESCRIPTION
This pull request introduces support for plugin metrics collection in the `surf-npc-bukkit` module and updates the project version. The key changes include initializing a new `Metrics` instance during plugin startup and ensuring proper shutdown of metrics on plugin disable.

**Metrics Integration:**
* Added a `Metrics` field to the `BukkitMain` class and imported the required `Metrics` class. The metrics system is initialized in `onEnable()` with a specific plugin ID (`27049`). [[1]](diffhunk://#diff-17beeae24d328bd6ae1b7851b3752a2752e70de665c19e72b5e4fcfd06c6d7dfR15-R20) [[2]](diffhunk://#diff-17beeae24d328bd6ae1b7851b3752a2752e70de665c19e72b5e4fcfd06c6d7dfR29-R30)
* Ensured the `Metrics` instance is properly shut down in `onDisable()` to clean up resources.

**Version Update:**
* Updated the project version in `gradle.properties` from `1.21.7-1.4.2-SNAPSHOT` to `1.21.7-1.4.3-SNAPSHOT`.