### PR TITLE
Feat/update checker

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
 kotlin.code.style=official
 kotlin.stdlib.default.dependency=false
 org.gradle.parallel=true
-version=1.21.7-1.4.6-SNAPSHOT
+version=1.21.7-1.4.7-SNAPSHOT

--- a/surf-npc-bukkit/build.gradle.kts
+++ b/surf-npc-bukkit/build.gradle.kts
@@ -6,8 +6,6 @@ dependencies {
     api(project(":surf-npc-core"))
 }
 
-version = "1.21.7-1.0.0-SNAPSHOT"
-
 surfPaperPluginApi {
     mainClass("dev.slne.surf.npc.bukkit.BukkitMain")
     authors.add("red")

--- a/surf-npc-bukkit/build.gradle.kts
+++ b/surf-npc-bukkit/build.gradle.kts
@@ -6,6 +6,8 @@ dependencies {
     api(project(":surf-npc-core"))
 }
 
+version = "1.21.7-1.0.0-SNAPSHOT"
+
 surfPaperPluginApi {
     mainClass("dev.slne.surf.npc.bukkit.BukkitMain")
     authors.add("red")

--- a/surf-npc-bukkit/src/main/kotlin/dev/slne/surf/npc/bukkit/BukkitMain.kt
+++ b/surf-npc-bukkit/src/main/kotlin/dev/slne/surf/npc/bukkit/BukkitMain.kt
@@ -3,6 +3,7 @@ package dev.slne.surf.npc.bukkit
 import com.github.retrooper.packetevents.PacketEvents
 import com.github.retrooper.packetevents.event.PacketListenerPriority
 import com.github.shynixn.mccoroutine.folia.SuspendingJavaPlugin
+import com.github.shynixn.mccoroutine.folia.launch
 import dev.slne.surf.npc.api.npc.property.NpcPropertyType
 import dev.slne.surf.npc.bukkit.command.NpcCommand
 import dev.slne.surf.npc.bukkit.listener.ConnectionListener
@@ -50,10 +51,10 @@ class BukkitMain : SuspendingJavaPlugin() {
         storageService.loadNpcs()
 
         NpcCommand("npc").register()
-    }
 
-    override suspend fun onEnableAsync() {
-        versionService.fetchGithubVersion()
+        launch {
+            versionService.fetchGithubVersion()
+        }
     }
 
     override fun onDisable() {

--- a/surf-npc-bukkit/src/main/kotlin/dev/slne/surf/npc/bukkit/BukkitMain.kt
+++ b/surf-npc-bukkit/src/main/kotlin/dev/slne/surf/npc/bukkit/BukkitMain.kt
@@ -10,6 +10,7 @@ import dev.slne.surf.npc.bukkit.listener.InternalNpcEventListener
 import dev.slne.surf.npc.bukkit.listener.NpcListener
 import dev.slne.surf.npc.bukkit.listener.WorldChangeListener
 import dev.slne.surf.npc.bukkit.npc.property.impl.*
+import dev.slne.surf.npc.bukkit.service.versionService
 import dev.slne.surf.npc.core.property.propertyTypeRegistry
 import dev.slne.surf.npc.core.service.storageService
 import dev.slne.surf.surfapi.bukkit.api.event.register
@@ -49,6 +50,10 @@ class BukkitMain : SuspendingJavaPlugin() {
         storageService.loadNpcs()
 
         NpcCommand("npc").register()
+    }
+
+    override suspend fun onEnableAsync() {
+        versionService.fetchGithubVersion()
     }
 
     override fun onDisable() {

--- a/surf-npc-bukkit/src/main/kotlin/dev/slne/surf/npc/bukkit/command/NpcCommand.kt
+++ b/surf-npc-bukkit/src/main/kotlin/dev/slne/surf/npc/bukkit/command/NpcCommand.kt
@@ -27,5 +27,7 @@ class NpcCommand(commandName: String) : CommandAPICommand(commandName) {
         subcommand(NpcSaveToDiskCommand("saveToDisk"))
         subcommand(NpcRefreshCommand("refresh"))
         subcommand(NpcAnimateCommand("animate"))
+
+        npcVersionCommand()
     }
 }

--- a/surf-npc-bukkit/src/main/kotlin/dev/slne/surf/npc/bukkit/command/sub/NpcVersionCommand.kt
+++ b/surf-npc-bukkit/src/main/kotlin/dev/slne/surf/npc/bukkit/command/sub/NpcVersionCommand.kt
@@ -1,0 +1,51 @@
+package dev.slne.surf.npc.bukkit.command.sub
+
+import com.github.shynixn.mccoroutine.folia.launch
+import dev.jorel.commandapi.CommandAPICommand
+import dev.jorel.commandapi.kotlindsl.anyExecutor
+import dev.jorel.commandapi.kotlindsl.subcommand
+import dev.slne.surf.npc.bukkit.plugin
+import dev.slne.surf.npc.bukkit.service.versionService
+import dev.slne.surf.npc.bukkit.util.PermissionRegistry
+import dev.slne.surf.surfapi.core.api.messages.adventure.clickOpensUrl
+import dev.slne.surf.surfapi.core.api.messages.adventure.sendText
+
+fun CommandAPICommand.npcVersionCommand() = subcommand("version") {
+    withPermission(PermissionRegistry.COMMAND_NPC_VERSION)
+    anyExecutor { executor, _ ->
+        plugin.launch {
+            executor.sendText {
+                appendPrefix()
+                if (versionService.isUpToDate()) info("Das Plugin ist up-to-date.") else variableKey(
+                    "Es gibt eine neuere Version."
+                )
+
+                versionService.currentVersion.let {
+                    appendNewline {
+                        appendPrefix()
+                        variableKey("Aktuelle Version: ")
+                        variableValue(it.toString())
+                    }
+                }
+
+                versionService.latestVersion.let {
+                    appendNewline {
+                        appendPrefix()
+                        variableKey("Neueste Version: ")
+                        variableValue(it.toString())
+                    }
+                }
+
+                appendNewline {
+                    appendPrefix()
+                    info("Neuste Version herunterladen: ")
+                    variableKey("[DOWNLOAD]")
+                    clickOpensUrl(
+                        versionService.link
+                            ?: "http://github.com/SLNE-Development/surf-npc/releases/latest"
+                    )
+                }
+            }
+        }
+    }
+}

--- a/surf-npc-bukkit/src/main/kotlin/dev/slne/surf/npc/bukkit/command/sub/NpcVersionCommand.kt
+++ b/surf-npc-bukkit/src/main/kotlin/dev/slne/surf/npc/bukkit/command/sub/NpcVersionCommand.kt
@@ -15,6 +15,7 @@ fun CommandAPICommand.npcVersionCommand() = subcommand("version") {
     anyExecutor { executor, _ ->
         plugin.launch {
             executor.sendText {
+                appendNewline()
                 appendPrefix()
                 if (versionService.isUpToDate()) info("Das Plugin ist up-to-date.") else variableKey(
                     "Es gibt eine neuere Version."
@@ -38,8 +39,8 @@ fun CommandAPICommand.npcVersionCommand() = subcommand("version") {
 
                 appendNewline {
                     appendPrefix()
-                    info("Neuste Version herunterladen: ")
-                    variableKey("[DOWNLOAD]")
+                    success("Neuste Version herunterladen: ")
+                    variableValue("[DOWNLOAD]")
                     clickOpensUrl(
                         versionService.link
                             ?: "http://github.com/SLNE-Development/surf-npc/releases/latest"

--- a/surf-npc-bukkit/src/main/kotlin/dev/slne/surf/npc/bukkit/listener/ConnectionListener.kt
+++ b/surf-npc-bukkit/src/main/kotlin/dev/slne/surf/npc/bukkit/listener/ConnectionListener.kt
@@ -5,6 +5,7 @@ import dev.slne.surf.npc.api.npc.property.NpcProperty
 import dev.slne.surf.npc.bukkit.service.versionService
 import dev.slne.surf.npc.bukkit.util.PermissionRegistry
 import dev.slne.surf.npc.core.controller.npcController
+import dev.slne.surf.surfapi.core.api.font.toSmallCaps
 import dev.slne.surf.surfapi.core.api.messages.adventure.clickOpensUrl
 import dev.slne.surf.surfapi.core.api.messages.adventure.sendText
 import org.bukkit.event.EventHandler
@@ -47,7 +48,11 @@ class ConnectionListener : Listener {
                     variableValue("surf-npc")
                     appendSpace()
                     info("verfügbar!")
-                    spacer("Klicke, um den neusten Release herunterzuladen.")
+                    appendNewline()
+                    appendPrefix()
+                    spacer(
+                        "Klicke hier, um den neusten Release herunterzuladen.".toSmallCaps()
+                    )
                     clickOpensUrl(
                         versionService.link
                             ?: "http://github.com/SLNE-Development/surf-npc/releases/latest"

--- a/surf-npc-bukkit/src/main/kotlin/dev/slne/surf/npc/bukkit/listener/ConnectionListener.kt
+++ b/surf-npc-bukkit/src/main/kotlin/dev/slne/surf/npc/bukkit/listener/ConnectionListener.kt
@@ -2,7 +2,11 @@ package dev.slne.surf.npc.bukkit.listener
 
 import dev.slne.surf.npc.api.npc.location.NpcLocation
 import dev.slne.surf.npc.api.npc.property.NpcProperty
+import dev.slne.surf.npc.bukkit.service.versionService
+import dev.slne.surf.npc.bukkit.util.PermissionRegistry
 import dev.slne.surf.npc.core.controller.npcController
+import dev.slne.surf.surfapi.core.api.messages.adventure.clickOpensUrl
+import dev.slne.surf.surfapi.core.api.messages.adventure.sendText
 import org.bukkit.event.EventHandler
 import org.bukkit.event.Listener
 import org.bukkit.event.player.PlayerJoinEvent
@@ -25,5 +29,31 @@ class ConnectionListener : Listener {
             .forEach {
                 it.spawn(player.uniqueId)
             }
+
+        if (player.hasPermission(PermissionRegistry.UPDATE_NOTIFY)) {
+            if (versionService.isUpToDate()) {
+                return
+            }
+
+            versionService.latestVersion?.let {
+                player.sendText {
+                    appendPrefix()
+                    info("Es ist eine")
+                    appendSpace()
+                    variableValue("neue Version")
+                    appendSpace()
+                    info("von")
+                    appendSpace()
+                    variableValue("surf-npc")
+                    appendSpace()
+                    info("verfügbar!")
+                    spacer("Klicke, um den neusten Release herunterzuladen.")
+                    clickOpensUrl(
+                        versionService.link
+                            ?: "http://github.com/SLNE-Development/surf-npc/releases/latest"
+                    )
+                }
+            }
+        }
     }
 }

--- a/surf-npc-bukkit/src/main/kotlin/dev/slne/surf/npc/bukkit/service/BukkitStorageService.kt
+++ b/surf-npc-bukkit/src/main/kotlin/dev/slne/surf/npc/bukkit/service/BukkitStorageService.kt
@@ -1,4 +1,4 @@
-package dev.slne.surf.npc.bukkit.storage
+package dev.slne.surf.npc.bukkit.service
 
 import com.google.auto.service.AutoService
 import dev.slne.surf.npc.api.npc.Npc

--- a/surf-npc-bukkit/src/main/kotlin/dev/slne/surf/npc/bukkit/service/VersionService.kt
+++ b/surf-npc-bukkit/src/main/kotlin/dev/slne/surf/npc/bukkit/service/VersionService.kt
@@ -1,0 +1,61 @@
+package dev.slne.surf.npc.bukkit.service
+
+import dev.slne.surf.npc.bukkit.util.SurfPluginVersion
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+
+import java.io.BufferedReader
+import java.io.InputStreamReader
+import java.net.HttpURLConnection
+import java.net.URI
+
+class VersionService {
+    var currentVersion = SurfPluginVersion.local()
+    var latestVersion: SurfPluginVersion? = null
+    var link: String? = null
+
+    private val fetchUrl = "https://api.github.com/repos/SLNE-DEVELOPMENT/surf-npc/releases/latest"
+
+    fun isUpToDate() = !(latestVersion?.isNewerThen(currentVersion) ?: false)
+
+    suspend fun fetchGithubVersion() = withContext(Dispatchers.IO) {
+        runCatching {
+            val url = URI(fetchUrl).toURL()
+            val connection = url.openConnection() as HttpURLConnection
+
+            connection.connectTimeout = 5000
+            connection.readTimeout = 5000
+            connection.requestMethod = "GET"
+            connection.setRequestProperty("Accept", "application/vnd.github.v3+json")
+
+            if (connection.responseCode == 200) {
+                val body =
+                    BufferedReader(InputStreamReader(connection.inputStream)).use { it.readText() }
+                val json = Json.parseToJsonElement(body).jsonObject
+                val latestTag = json["tag_name"]?.jsonPrimitive?.content
+                val link = json["url"]?.jsonPrimitive?.content
+
+                link?.let {
+                    this@VersionService.link = it
+                }
+
+                latestTag?.let {
+                    this@VersionService.latestVersion =
+                        SurfPluginVersion.fromString(latestTag.removePrefix("v"))
+                }
+            }
+
+            connection.disconnect()
+        }
+    }
+
+    companion object {
+        val INSTANCE = VersionService()
+    }
+}
+
+val versionService get() = VersionService.INSTANCE

--- a/surf-npc-bukkit/src/main/kotlin/dev/slne/surf/npc/bukkit/service/VersionService.kt
+++ b/surf-npc-bukkit/src/main/kotlin/dev/slne/surf/npc/bukkit/service/VersionService.kt
@@ -21,7 +21,7 @@ class VersionService {
 
     private val fetchUrl = "https://api.github.com/repos/SLNE-DEVELOPMENT/surf-npc/releases/latest"
 
-    fun isUpToDate() = !(latestVersion?.isNewerThen(currentVersion) ?: false)
+    fun isUpToDate() = !(latestVersion?.isNewerThan(currentVersion) ?: false)
 
     suspend fun fetchGithubVersion() = withContext(Dispatchers.IO) {
         runCatching {

--- a/surf-npc-bukkit/src/main/kotlin/dev/slne/surf/npc/bukkit/service/VersionService.kt
+++ b/surf-npc-bukkit/src/main/kotlin/dev/slne/surf/npc/bukkit/service/VersionService.kt
@@ -1,6 +1,7 @@
 package dev.slne.surf.npc.bukkit.service
 
 import dev.slne.surf.npc.bukkit.util.SurfPluginVersion
+import dev.slne.surf.surfapi.core.api.util.logger
 
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
@@ -37,7 +38,7 @@ class VersionService {
                     BufferedReader(InputStreamReader(connection.inputStream)).use { it.readText() }
                 val json = Json.parseToJsonElement(body).jsonObject
                 val latestTag = json["tag_name"]?.jsonPrimitive?.content
-                val link = json["url"]?.jsonPrimitive?.content
+                val link = json["html_url"]?.jsonPrimitive?.content
 
                 link?.let {
                     this@VersionService.link = it
@@ -47,9 +48,13 @@ class VersionService {
                     this@VersionService.latestVersion =
                         SurfPluginVersion.fromString(latestTag.removePrefix("v"))
                 }
+            } else {
+                logger().atWarning().log("Version Request failed with ${connection.responseCode}")
             }
 
             connection.disconnect()
+        }.onFailure {
+            logger().atWarning().log("Version Request failed: ${it.message}")
         }
     }
 

--- a/surf-npc-bukkit/src/main/kotlin/dev/slne/surf/npc/bukkit/util/PermissionRegistry.kt
+++ b/surf-npc-bukkit/src/main/kotlin/dev/slne/surf/npc/bukkit/util/PermissionRegistry.kt
@@ -33,4 +33,6 @@ object PermissionRegistry : PermissionRegistry() {
     val COMMAND_NPC_EXPORT_ALL = create("$PREFIX.command.exportall")
     val COMMAND_NPC_RELOAD_FROM_DISK = create("$PREFIX.command.loadFromDisk")
     val COMMAND_NPC_SAVE_TO_DISK = create("$PREFIX.command.saveToDisk")
+
+    val UPDATE_NOTIFY = create("$PREFIX.updates")
 }

--- a/surf-npc-bukkit/src/main/kotlin/dev/slne/surf/npc/bukkit/util/PermissionRegistry.kt
+++ b/surf-npc-bukkit/src/main/kotlin/dev/slne/surf/npc/bukkit/util/PermissionRegistry.kt
@@ -34,5 +34,6 @@ object PermissionRegistry : PermissionRegistry() {
     val COMMAND_NPC_RELOAD_FROM_DISK = create("$PREFIX.command.loadFromDisk")
     val COMMAND_NPC_SAVE_TO_DISK = create("$PREFIX.command.saveToDisk")
 
+    val COMMAND_NPC_VERSION = create("$PREFIX.command.version")
     val UPDATE_NOTIFY = create("$PREFIX.updates")
 }

--- a/surf-npc-bukkit/src/main/kotlin/dev/slne/surf/npc/bukkit/util/SurfPluginVersion.kt
+++ b/surf-npc-bukkit/src/main/kotlin/dev/slne/surf/npc/bukkit/util/SurfPluginVersion.kt
@@ -11,7 +11,7 @@ data class SurfPluginVersion(
         return "$mcVersion-$pluginVersion${if (isSnapshot) "-SNAPSHOT" else ""}"
     }
 
-    fun isNewerThen(other: SurfPluginVersion?): Boolean {
+    fun isNewerThan(other: SurfPluginVersion?): Boolean {
         if (other == null) return true
 
         val mcPartsThis = this.mcVersion.split(".").mapNotNull { it.toIntOrNull() }

--- a/surf-npc-bukkit/src/main/kotlin/dev/slne/surf/npc/bukkit/util/SurfPluginVersion.kt
+++ b/surf-npc-bukkit/src/main/kotlin/dev/slne/surf/npc/bukkit/util/SurfPluginVersion.kt
@@ -1,0 +1,70 @@
+package dev.slne.surf.npc.bukkit.util
+
+import dev.slne.surf.npc.bukkit.plugin
+
+data class SurfPluginVersion(
+    val mcVersion: String,
+    val pluginVersion: String,
+    val isSnapshot: Boolean = false
+) {
+    override fun toString(): String {
+        return "$mcVersion-$pluginVersion${if (isSnapshot) "-SNAPSHOT" else ""}"
+    }
+
+    fun isNewerThen(other: SurfPluginVersion?): Boolean {
+        if (other == null) return true
+
+        val mcPartsThis = this.mcVersion.split(".").mapNotNull { it.toIntOrNull() }
+        val mcPartsOther = other.mcVersion.split(".").mapNotNull { it.toIntOrNull() }
+        val mcLength = maxOf(mcPartsThis.size, mcPartsOther.size)
+
+        for (i in 0 until mcLength) {
+            val thisPart = mcPartsThis.getOrNull(i) ?: 0
+            val otherPart = mcPartsOther.getOrNull(i) ?: 0
+            if (thisPart > otherPart) return true
+            if (thisPart < otherPart) return false
+        }
+
+        val pluginPartsThis = this.pluginVersion.split(".").mapNotNull { it.toIntOrNull() }
+        val pluginPartsOther = other.pluginVersion.split(".").mapNotNull { it.toIntOrNull() }
+        val pluginLength = maxOf(pluginPartsThis.size, pluginPartsOther.size)
+
+        for (i in 0 until pluginLength) {
+            val thisPart = pluginPartsThis.getOrNull(i) ?: 0
+            val otherPart = pluginPartsOther.getOrNull(i) ?: 0
+            if (thisPart > otherPart) return true
+            if (thisPart < otherPart) return false
+        }
+
+        return this.isSnapshot && !other.isSnapshot
+    }
+
+
+    companion object {
+        fun local(): SurfPluginVersion {
+            val desc = plugin.pluginMeta
+            val version = desc.version
+
+            val parts = version.split("-")
+            val mcVersion = parts.getOrNull(0) ?: "unknown"
+            val pluginVersion = parts.getOrNull(1) ?: "unknown"
+            val isSnapshot = parts.size > 2 && parts[2].equals("SNAPSHOT", ignoreCase = true)
+
+            return SurfPluginVersion(
+                mcVersion = mcVersion,
+                pluginVersion = pluginVersion,
+                isSnapshot = isSnapshot
+            )
+        }
+
+        fun fromString(version: String): SurfPluginVersion {
+            val parts = version.split("-")
+            val mcVersion = parts.getOrNull(0) ?: "unknown"
+            val pluginVersion = parts.getOrNull(1) ?: "unknown"
+            val isSnapshot = parts.size > 2 && parts[2].equals("SNAPSHOT", ignoreCase = true)
+
+            return SurfPluginVersion(mcVersion, pluginVersion, isSnapshot)
+        }
+    }
+
+}


### PR DESCRIPTION
This pull request introduces a version checking and update notification system for the plugin, allowing both administrators and players with the appropriate permissions to be informed when a new version is available. It also refactors and organizes related code, including the addition of a new `VersionService` and version representation class, as well as updates to command and permission handling.

**Version Checking & Notification System:**

* Added a new `VersionService` (`VersionService.kt`) that fetches the latest plugin version from GitHub, determines if the current version is up-to-date, and provides the download link. This service is initialized on plugin startup. [[1]](diffhunk://#diff-cc473c31830d96782c84a260f5fa35dc64f371763dd0a94764ca61c96a66af21R1-R66) [[2]](diffhunk://#diff-17beeae24d328bd6ae1b7851b3752a2752e70de665c19e72b5e4fcfd06c6d7dfR54-R57)
* Introduced `SurfPluginVersion` class to represent and compare plugin versions, supporting both local and remote version parsing.
* On player join, players with the `UPDATE_NOTIFY` permission receive a clickable message if a newer version is available.

**Command Enhancements:**

* Added a new `/npc version` subcommand, gated by a new permission, which shows the current and latest plugin version and provides a download link. [[1]](diffhunk://#diff-51e6ca5f5f7e9349d69f052f531f75086369fef41d466610ef6833d36f7e5fd8R1-R52) [[2]](diffhunk://#diff-a8d1b56829287cfd16fd3cc7767e4af06ebf0bd41305c1401669a7cdaf998234R30-R31)
* Registered new permissions `COMMAND_NPC_VERSION` and `UPDATE_NOTIFY` in `PermissionRegistry`.

**Codebase Organization & Maintenance:**

* Moved `BukkitStorageService` from the `storage` package to the `service` package for better organization.
* Updated project version to `1.21.7-1.4.7-SNAPSHOT` in `gradle.properties`.

These changes collectively improve plugin maintainability, user awareness of updates, and code structure.