### PR TITLE
chore: update publish workflow to support pre/development branch handling

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - 'version/*'
+      - 'pre/development'
   workflow_dispatch:
 
 env:
@@ -66,17 +67,23 @@ jobs:
       - name: Determine release flags
         run: |
           CURRENT_BRANCH=${GITHUB_REF#refs/heads/}
-          # prerelease only for snapshots
-          if [ "${SNAPSHOT_FLAG}" = "true" ]; then
+
+          if [ "$CURRENT_BRANCH" = "pre/development" ]; then
             echo "PRERELEASE=true" >> $GITHUB_ENV
-          else
-            echo "PRERELEASE=false" >> $GITHUB_ENV
-          fi
-          # make_latest false for snapshots or non-default branches
-          if [ "${SNAPSHOT_FLAG}" = "true" ] || [ "${CURRENT_BRANCH}" != "${DEFAULT_BRANCH}" ]; then
             echo "MAKE_LATEST=false" >> $GITHUB_ENV
           else
-            echo "MAKE_LATEST=true" >> $GITHUB_ENV
+            # prerelease only for snapshots
+            if [ "${SNAPSHOT_FLAG}" = "true" ]; then
+              echo "PRERELEASE=true" >> $GITHUB_ENV
+            else
+              echo "PRERELEASE=false" >> $GITHUB_ENV
+            fi
+            # make_latest false for snapshots or non-default branches
+            if [ "${SNAPSHOT_FLAG}" = "true" ] || [ "${CURRENT_BRANCH}" != "${DEFAULT_BRANCH}" ]; then
+              echo "MAKE_LATEST=false" >> $GITHUB_ENV
+            else
+              echo "MAKE_LATEST=true" >> $GITHUB_ENV
+            fi
           fi
 
       - name: Find and filter JAR files

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -46,7 +46,9 @@ jobs:
       - name: Build all modules with Gradle
         run: ./gradlew build shadowJar --parallel --no-scan
 
+      # 👉 Nur ausführen, wenn NICHT pre/development
       - name: Publish all modules to Maven
+        if: github.ref != 'refs/heads/pre/development'
         run: ./gradlew publish --parallel --no-scan
 
       - name: Extract Project Version and Snapshot Flag from Gradle
@@ -72,13 +74,11 @@ jobs:
             echo "PRERELEASE=true" >> $GITHUB_ENV
             echo "MAKE_LATEST=false" >> $GITHUB_ENV
           else
-            # prerelease only for snapshots
             if [ "${SNAPSHOT_FLAG}" = "true" ]; then
               echo "PRERELEASE=true" >> $GITHUB_ENV
             else
               echo "PRERELEASE=false" >> $GITHUB_ENV
             fi
-            # make_latest false for snapshots or non-default branches
             if [ "${SNAPSHOT_FLAG}" = "true" ] || [ "${CURRENT_BRANCH}" != "${DEFAULT_BRANCH}" ]; then
               echo "MAKE_LATEST=false" >> $GITHUB_ENV
             else

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -45,8 +45,6 @@ jobs:
 
       - name: Build all modules with Gradle
         run: ./gradlew build shadowJar --parallel --no-scan
-
-      # 👉 Nur ausführen, wenn NICHT pre/development
       - name: Publish all modules to Maven
         if: github.ref != 'refs/heads/pre/development'
         run: ./gradlew publish --parallel --no-scan


### PR DESCRIPTION

This pull request updates the `.github/workflows/publish.yml` workflow to better handle the new `pre/development` branch. The main improvements ensure that publishing and release flags are correctly set for this branch, preventing unintended deployments and marking builds as pre-releases when appropriate.

Branch handling enhancements:

* Added `pre/development` to the list of branches that trigger the workflow on push events, ensuring CI runs for this branch.

Publishing logic updates:

* Modified the "Publish all modules to Maven" step to skip publishing when running on the `pre/development` branch, preventing accidental releases from this branch.

Release flag determination:

* Updated the "Determine release flags" step to always set `PRERELEASE=true` and `MAKE_LATEST=false` for the `pre/development` branch, ensuring these builds are treated as pre-releases and are not marked as the latest release.