### PR TITLE
chore: update version to 1.21.10-1.5.0-SNAPSHOT

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,7 +6,7 @@ buildscript {
         maven("https://repo.slne.dev/repository/maven-public/") { name = "maven-public" }
     }
     dependencies {
-        classpath("dev.slne.surf:surf-api-gradle-plugin:1.21.7+")
+        classpath("dev.slne.surf:surf-api-gradle-plugin:1.21.10+")
     }
 }
 
@@ -19,7 +19,7 @@ subprojects {
     afterEvaluate {
         plugins.withType<PublishingPlugin> {
             configure<PublishingExtension> {
-                repositories{
+                repositories {
                     slneReleases()
                 }
             }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
 kotlin.code.style=official
 kotlin.stdlib.default.dependency=false
 org.gradle.parallel=true
-version=1.21.7-1.5.0-SNAPSHOT
+version=1.21.10-1.5.0-SNAPSHOT


### PR DESCRIPTION
This pull request updates the project version in `gradle.properties` to `1.21.10-1.5.0-SNAPSHOT`, reflecting a new snapshot release.

* Version bump: Updated the `version` property from `1.21.7-1.5.0-SNAPSHOT` to `1.21.10-1.5.0-SNAPSHOT` in `gradle.properties`.