### PR TITLE
feat: Add scale property to NPCs and update related logic for scaling…

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
 kotlin.code.style=official
 kotlin.stdlib.default.dependency=false
 org.gradle.parallel=true
-version=1.6.4-SNAPSHOT
+version=1.6.5-SNAPSHOT

--- a/surf-npc-api/src/main/kotlin/dev/slne/surf/npc/api/SurfNpcApi.kt
+++ b/surf-npc-api/src/main/kotlin/dev/slne/surf/npc/api/SurfNpcApi.kt
@@ -52,12 +52,14 @@ interface SurfNpcApi {
     fun setLocation(npc: Npc, location: Location)
     fun setPersistence(npc: Npc, persistent: Boolean)
     fun setRotationType(npc: Npc, rotationType: NpcRotationType)
+    fun setScale(npc: Npc, scale: Double)
 
     fun getDisplayName(npc: Npc): Component
     fun getSkinData(npc: Npc): NpcSkin?
     fun getLocation(npc: Npc): Location
     fun isPersistent(npc: Npc): Boolean
     fun getRotationType(npc: Npc): NpcRotationType
+    fun getScale(npc: Npc): Double
 
     fun getProperties(npc: Npc): ObjectSet<NpcProperty>
     fun addProperty(npc: Npc, property: NpcProperty)
@@ -68,7 +70,9 @@ interface SurfNpcApi {
     fun getNpcs(): ObjectSet<Npc>
 
     fun setPose(npc: Npc, pose: NpcPose)
+    fun getPose(npc: Npc): NpcPose
 
+    @Suppress("DEPRECATION")
     companion object : SurfNpcApi by surfNpcApi
 }
 

--- a/surf-npc-api/src/main/kotlin/dev/slne/surf/npc/api/dsl/NpcDslBuilder.kt
+++ b/surf-npc-api/src/main/kotlin/dev/slne/surf/npc/api/dsl/NpcDslBuilder.kt
@@ -5,12 +5,12 @@ package dev.slne.surf.npc.api.dsl
 import dev.slne.surf.api.core.messages.builder.SurfComponentBuilder
 import dev.slne.surf.api.core.util.mutableObject2ObjectMapOf
 import dev.slne.surf.api.core.util.mutableObjectListOf
+import dev.slne.surf.npc.api.SurfNpcApi
 import dev.slne.surf.npc.api.event.NpcEvent
 import dev.slne.surf.npc.api.npc.Npc
 import dev.slne.surf.npc.api.npc.property.NpcProperty
 import dev.slne.surf.npc.api.npc.rotation.NpcRotationType
 import dev.slne.surf.npc.api.npc.skin.NpcSkin
-import dev.slne.surf.npc.api.surfNpcApi
 import it.unimi.dsi.fastutil.objects.ObjectList
 import it.unimi.dsi.fastutil.objects.ObjectSet
 import net.kyori.adventure.text.format.NamedTextColor
@@ -49,6 +49,8 @@ class NpcDslBuilder {
      * Whether the NPC is global. Defaults to true.
      */
     var viewers: ObjectSet<UUID>? = null
+
+    var scale: Double = 1.0
 
     /**
      * The rotation type of the NPC. Defaults to PER_PLAYER.
@@ -97,6 +99,10 @@ class NpcDslBuilder {
 
     fun displayName(block: SurfComponentBuilder.() -> Unit) {
         displayName = block
+    }
+
+    fun scale(scale: Double) {
+        this.scale = scale
     }
 
 
@@ -156,12 +162,12 @@ fun skin(block: SkinBuilder.() -> Unit): NpcSkin {
  * @return The retrieved NPC skin.
  */
 suspend fun fetchedSkin(name: String): NpcSkin {
-    return surfNpcApi.fetchSkin(name)
+    return SurfNpcApi.fetchSkin(name)
 }
 
 fun npc(block: NpcDslBuilder.() -> Unit): Npc {
     val builder = NpcDslBuilder().apply(block)
-    val npc = surfNpcApi.createNpc(
+    val npc = SurfNpcApi.createNpc(
         displayName = SurfComponentBuilder.builder().apply(builder.displayName).build(),
         uniqueName = builder.uniqueName,
         type = builder.type,
@@ -169,8 +175,10 @@ fun npc(block: NpcDslBuilder.() -> Unit): Npc {
         location = builder.location,
         viewers = builder.viewers,
         rotationType = builder.rotationType,
-        persistent = builder.persistent
+        persistent = builder.persistent,
     )
+
+    npc.setScale(builder.scale)
 
     builder.eventHandlers.forEach { (eventClass, handlersList) ->
         handlersList.forEach { handler ->

--- a/surf-npc-api/src/main/kotlin/dev/slne/surf/npc/api/npc/Npc.kt
+++ b/surf-npc-api/src/main/kotlin/dev/slne/surf/npc/api/npc/Npc.kt
@@ -3,12 +3,12 @@ package dev.slne.surf.npc.api.npc
 import dev.slne.surf.api.core.util.mutableObject2ObjectMapOf
 import dev.slne.surf.api.core.util.mutableObjectListOf
 import dev.slne.surf.api.core.util.toObjectSet
+import dev.slne.surf.npc.api.SurfNpcApi
 import dev.slne.surf.npc.api.event.NpcEvent
 import dev.slne.surf.npc.api.npc.property.NpcProperty
 import dev.slne.surf.npc.api.npc.property.NpcPropertyType
 import dev.slne.surf.npc.api.npc.rotation.NpcRotationType
 import dev.slne.surf.npc.api.npc.skin.NpcSkin
-import dev.slne.surf.npc.api.surfNpcApi
 import it.unimi.dsi.fastutil.objects.Object2ObjectMap
 import it.unimi.dsi.fastutil.objects.ObjectList
 import it.unimi.dsi.fastutil.objects.ObjectSet
@@ -73,49 +73,49 @@ data class Npc(
     private val eventHandlers =
         mutableObject2ObjectMapOf<KClass<out NpcEvent>, ObjectList<NpcEventHandler<*>>>()
 
-    fun show() = surfNpcApi.showNpc(this)
-    fun hide() = surfNpcApi.hideNpc(this)
+    fun show() = SurfNpcApi.showNpc(this)
+    fun hide() = SurfNpcApi.hideNpc(this)
 
-    fun refresh() = surfNpcApi.refreshNpc(this)
-    fun refreshRotation(uuid: UUID) = surfNpcApi.refreshRotation(this)
+    fun refresh() = SurfNpcApi.refreshNpc(this)
+    fun refreshRotation() = SurfNpcApi.refreshRotation(this)
 
-    fun delete() = surfNpcApi.deleteNpc(this)
-    fun teleport(player: Player) = surfNpcApi.teleport(this, player)
+    fun delete() = SurfNpcApi.deleteNpc(this)
+    fun teleport(player: Player) = SurfNpcApi.teleport(this, player)
     fun retrieveViewers(): ObjectSet<UUID> =
         viewers ?: Bukkit.getOnlinePlayers().map { it.uniqueId }.toObjectSet()
 
     fun forEachViewer(action: (UUID) -> Unit) = retrieveViewers().forEach(action)
 
-    fun addProperty(property: NpcProperty) = surfNpcApi.editNpc(this) {
+    fun addProperty(property: NpcProperty) = SurfNpcApi.editNpc(this) {
         this.properties[property.key] = property
     }
 
     fun addProperties(vararg properties: Triple<String, Any, NpcPropertyType>) =
-        surfNpcApi.editNpc(this) {
+        SurfNpcApi.editNpc(this) {
             properties.forEach { (key, value, type) ->
                 this.properties[key] = NpcProperty(key, value, type)
             }
         }
 
-    fun addProperties(vararg properties: NpcProperty) = surfNpcApi.editNpc(this) {
+    fun addProperties(vararg properties: NpcProperty) = SurfNpcApi.editNpc(this) {
         properties.forEach { this.properties[it.key] = it }
     }
 
     fun getProperty(key: String): NpcProperty? = properties[key]
 
     fun setEquipment(slot: EquipmentSlot, item: ItemStack) =
-        surfNpcApi.setEquipment(this, slot, item)
+        SurfNpcApi.setEquipment(this, slot, item)
 
     @Suppress("UNCHECKED_CAST")
     fun <T : Any> getPropertyValue(key: String, clazz: KClass<T>): T? =
         getProperty(key)?.value as? T
 
-    fun removeProperty(key: String) = surfNpcApi.editNpc(this) {
+    fun removeProperty(key: String) = SurfNpcApi.editNpc(this) {
         this.properties.remove(key)
     }
 
     fun hasProperty(key: String): Boolean = getProperty(key) != null
-    fun clearProperties() = surfNpcApi.editNpc(this) {
+    fun clearProperties() = SurfNpcApi.editNpc(this) {
         this.properties.clear()
     }
 
@@ -135,25 +135,29 @@ data class Npc(
     fun <T : NpcEvent> callHandlers(event: T) =
         eventHandlers[event::class]?.forEach { (it as NpcEventHandler<T>)(event) }
 
-    fun save() = surfNpcApi.saveNpc(this)
+    fun save() = SurfNpcApi.saveNpc(this)
 
-    fun addViewer(uuid: UUID) = surfNpcApi.addViewer(this, uuid)
-    fun removeViewer(uuid: UUID) = surfNpcApi.removeViewer(this, uuid)
-    fun hasViewer(uuid: UUID): Boolean = surfNpcApi.hasViewer(this, uuid)
-    fun clearViewers() = surfNpcApi.clearViewers(this)
+    fun addViewer(uuid: UUID) = SurfNpcApi.addViewer(this, uuid)
+    fun removeViewer(uuid: UUID) = SurfNpcApi.removeViewer(this, uuid)
+    fun hasViewer(uuid: UUID): Boolean = SurfNpcApi.hasViewer(this, uuid)
+    fun clearViewers() = SurfNpcApi.clearViewers(this)
 
-    fun setDisplayName(displayName: Component) = surfNpcApi.setDisplayName(this, displayName)
-    fun setSkinData(skin: NpcSkin) = surfNpcApi.setSkinData(this, skin)
-    fun setLocation(location: Location) = surfNpcApi.setLocation(this, location)
-    fun setPersistence(persistent: Boolean) = surfNpcApi.setPersistence(this, persistent)
+    fun setDisplayName(displayName: Component) = SurfNpcApi.setDisplayName(this, displayName)
+    fun setSkinData(skin: NpcSkin) = SurfNpcApi.setSkinData(this, skin)
+    fun setLocation(location: Location) = SurfNpcApi.setLocation(this, location)
+    fun setPersistence(persistent: Boolean) = SurfNpcApi.setPersistence(this, persistent)
     fun setRotationType(rotationType: NpcRotationType) =
-        surfNpcApi.setRotationType(this, rotationType)
+        SurfNpcApi.setRotationType(this, rotationType)
 
-    fun getDisplayName(): Component = surfNpcApi.getDisplayName(this)
-    fun getSkinData(): NpcSkin? = surfNpcApi.getSkinData(this)
-    fun getLocation(): Location = surfNpcApi.getLocation(this)
-    fun isPersistent(): Boolean = surfNpcApi.isPersistent(this)
-    fun getRotationType(): NpcRotationType = surfNpcApi.getRotationType(this)
+    fun setScale(scale: Double) = SurfNpcApi.setScale(this, scale)
 
-    fun setPose(pose: NpcPose) = surfNpcApi.setPose(this, pose)
+    fun getDisplayName(): Component = SurfNpcApi.getDisplayName(this)
+    fun getSkinData(): NpcSkin? = SurfNpcApi.getSkinData(this)
+    fun getLocation(): Location = SurfNpcApi.getLocation(this)
+    fun getPose(): NpcPose = SurfNpcApi.getPose(this)
+    fun isPersistent(): Boolean = SurfNpcApi.isPersistent(this)
+    fun getRotationType(): NpcRotationType = SurfNpcApi.getRotationType(this)
+    fun getScale(): Double = SurfNpcApi.getScale(this)
+
+    fun setPose(pose: NpcPose) = SurfNpcApi.setPose(this, pose)
 }

--- a/surf-npc-api/src/main/kotlin/dev/slne/surf/npc/api/npc/property/NpcProperty.kt
+++ b/surf-npc-api/src/main/kotlin/dev/slne/surf/npc/api/npc/property/NpcProperty.kt
@@ -13,29 +13,12 @@ data class NpcProperty(
     val type: NpcPropertyType
 ) {
     object Internal {
-        /**
-         * The display name of the NPC.
-         */
         const val DISPLAYNAME = "displayname"
-
-        /**
-         * The skin data of the NPC.
-         */
         const val SKIN_DATA = "skin_data"
-
-        /**
-         * The location of the NPC.
-         */
         const val LOCATION = "location"
-
-        /**
-         * The type of rotation for the NPC.
-         */
         const val ROTATION_TYPE = "rotation_type"
-
-        /**
-         * The persistence of the NPC.
-         */
         const val PERSISTENCE = "persistence"
+        const val SCALE = "scale"
+        const val POSE = "pose"
     }
 }

--- a/surf-npc-api/src/main/kotlin/dev/slne/surf/npc/api/npc/property/NpcPropertyType.kt
+++ b/surf-npc-api/src/main/kotlin/dev/slne/surf/npc/api/npc/property/NpcPropertyType.kt
@@ -1,6 +1,6 @@
 package dev.slne.surf.npc.api.npc.property
 
-import dev.slne.surf.npc.api.surfNpcApi
+import dev.slne.surf.npc.api.SurfNpcApi
 
 /**
  * Represents the type of a property associated with an NPC.
@@ -12,20 +12,22 @@ interface NpcPropertyType {
     fun decode(value: String): Any
 
     object Types {
-        val BOOLEAN_TYPE get() = surfNpcApi.getPropertyTypeOrThrow(BOOLEAN_ID)
-        val INT_TYPE get() = surfNpcApi.getPropertyTypeOrThrow(INT_ID)
-        val LONG_TYPE get() = surfNpcApi.getPropertyTypeOrThrow(LONG_ID)
-        val STRING_TYPE get() = surfNpcApi.getPropertyTypeOrThrow(STRING_ID)
-        val DOUBLE_TYPE get() = surfNpcApi.getPropertyTypeOrThrow(DOUBLE_ID)
-        val FLOAT_TYPE get() = surfNpcApi.getPropertyTypeOrThrow(FLOAT_ID)
-        val UUID_TYPE get() = surfNpcApi.getPropertyTypeOrThrow(UUID_ID)
-        val NAMED_TEXT_COLOR_TYPE get() = surfNpcApi.getPropertyTypeOrThrow(NAMED_TEXT_COLOR_ID)
-        val COMPONENT_TYPE get() = surfNpcApi.getPropertyTypeOrThrow(COMPONENT_ID)
-        val SKIN_DATA_TYPE get() = surfNpcApi.getPropertyTypeOrThrow(SKIN_DATA_ID)
-        val LOCATION_TYPE get() = surfNpcApi.getPropertyTypeOrThrow(LOCATION_ID)
-        val ROTATION_TYPE_TYPE get() = surfNpcApi.getPropertyTypeOrThrow(ROTATION_TYPE_ID)
+        val BOOLEAN_TYPE get() = SurfNpcApi.getPropertyTypeOrThrow(BOOLEAN_ID)
+        val INT_TYPE get() = SurfNpcApi.getPropertyTypeOrThrow(INT_ID)
+        val LONG_TYPE get() = SurfNpcApi.getPropertyTypeOrThrow(LONG_ID)
+        val STRING_TYPE get() = SurfNpcApi.getPropertyTypeOrThrow(STRING_ID)
+        val DOUBLE_TYPE get() = SurfNpcApi.getPropertyTypeOrThrow(DOUBLE_ID)
+        val FLOAT_TYPE get() = SurfNpcApi.getPropertyTypeOrThrow(FLOAT_ID)
+        val UUID_TYPE get() = SurfNpcApi.getPropertyTypeOrThrow(UUID_ID)
+        val NAMED_TEXT_COLOR_TYPE get() = SurfNpcApi.getPropertyTypeOrThrow(NAMED_TEXT_COLOR_ID)
+        val COMPONENT_TYPE get() = SurfNpcApi.getPropertyTypeOrThrow(COMPONENT_ID)
+        val SKIN_DATA_TYPE get() = SurfNpcApi.getPropertyTypeOrThrow(SKIN_DATA_ID)
+        val LOCATION_TYPE get() = SurfNpcApi.getPropertyTypeOrThrow(LOCATION_ID)
+        val ROTATION_TYPE_TYPE get() = SurfNpcApi.getPropertyTypeOrThrow(ROTATION_TYPE_ID)
+        val NPC_POSE get() = SurfNpcApi.getPropertyTypeOrThrow(NPC_POSE_ID)
 
         const val BOOLEAN_ID = "boolean"
+        const val NPC_POSE_ID = "pose"
 
         /**
          * Represents an integer property type.

--- a/surf-npc-example-dsl/src/main/kotlin/dev/slne/surf/npc/example/SurfNpcExamplePlugin.kt
+++ b/surf-npc-example-dsl/src/main/kotlin/dev/slne/surf/npc/example/SurfNpcExamplePlugin.kt
@@ -58,6 +58,8 @@ class SurfNpcExamplePlugin() : SuspendingJavaPlugin() {
                 }
             }
 
+            scale(2.0)
+
             /**
              * Location can be created using the DSL.
              */

--- a/surf-npc-paper/src/main/kotlin/dev/slne/surf/npc/paper/PaperMain.kt
+++ b/surf-npc-paper/src/main/kotlin/dev/slne/surf/npc/paper/PaperMain.kt
@@ -42,6 +42,7 @@ class PaperMain : SuspendingJavaPlugin() {
         propertyTypeRegistry.register(NamedTextColorPropertyType(NpcPropertyType.Types.NAMED_TEXT_COLOR_ID))
         propertyTypeRegistry.register(SkinDataPropertyType(NpcPropertyType.Types.SKIN_DATA_ID))
         propertyTypeRegistry.register(RotationTypePropertyType(NpcPropertyType.Types.ROTATION_TYPE_ID))
+        propertyTypeRegistry.register(NpcPosePropertyType(NpcPropertyType.Types.NPC_POSE_ID))
 
         npcStorageService.initialize()
         npcStorageService.loadAll()

--- a/surf-npc-paper/src/main/kotlin/dev/slne/surf/npc/paper/PaperPackets.kt
+++ b/surf-npc-paper/src/main/kotlin/dev/slne/surf/npc/paper/PaperPackets.kt
@@ -1,5 +1,6 @@
 package dev.slne.surf.npc.paper
 
+import com.github.retrooper.packetevents.protocol.attribute.Attributes
 import com.github.retrooper.packetevents.protocol.component.builtin.item.ItemProfile
 import com.github.retrooper.packetevents.protocol.entity.data.EntityData
 import com.github.retrooper.packetevents.protocol.entity.data.EntityDataTypes
@@ -145,6 +146,22 @@ sealed class BukkitPackets {
             )
         }
 
+        data class NpcSetScalePacket(
+            val entityId: Int,
+            val scale: Double
+        ) : NpcPackets() {
+            override fun build() = WrapperPlayServerUpdateAttributes(
+                entityId,
+                listOf(
+                    WrapperPlayServerUpdateAttributes.Property(
+                        Attributes.SCALE,
+                        scale,
+                        listOf()
+                    )
+                )
+            )
+        }
+
         class NpcDestroyPacket(vararg val entityIds: Int) : NpcPackets() {
             override fun build() = WrapperPlayServerDestroyEntities(*entityIds)
         }
@@ -154,13 +171,14 @@ sealed class BukkitPackets {
         data class NameTagSpawnPacket(
             val entityId: Int,
             val uuid: UUID,
-            val location: BukkitLocation
+            val location: BukkitLocation,
+            val scale: Double
         ) : NpcNameTagPackets() {
             override fun build() = WrapperPlayServerSpawnEntity(
                 entityId,
                 uuid,
                 EntityTypes.TEXT_DISPLAY,
-                PacketLocation(Vector3d(location.x, location.y + 2, location.z), 0f, 0f),
+                PacketLocation(Vector3d(location.x, location.y + 2.0 * scale, location.z), 0f, 0f),
                 0f,
                 0,
                 null
@@ -179,14 +197,12 @@ sealed class BukkitPackets {
         }
 
         data class NameTagCorrectionPacket(
-            val entityId: Int,
-            val npcLocation: BukkitLocation,
-            val npcPose: NpcPose
+            val npc: Npc
         ) : NpcNameTagPackets() {
             override fun build() = WrapperPlayServerEntityTeleport(
-                entityId,
+                npc.id,
                 SpigotConversionUtil.fromBukkitLocation(
-                    calculateNametagLocation(npcPose, npcLocation).add(0.0, 2.0, 0.0)
+                    calculateNametagLocation(npc.getPose(), npc.getLocation(), npc.getScale())
                 ),
                 false
             )
@@ -256,16 +272,19 @@ sealed class BukkitPackets {
 
 private fun calculateNametagLocation(
     npcPose: NpcPose,
-    npcLocation: BukkitLocation
-): BukkitLocation =
-    when (npcPose) {
-        NpcPose.SNEAKING -> npcLocation.clone().subtract(0.0, 0.2, 0.0)
-        NpcPose.SITTING -> npcLocation.clone().subtract(0.0, 0.62, 0.0)
-        NpcPose.SWIMMING, NpcPose.FALL_FLYING, NpcPose.SLEEPING -> npcLocation.clone()
-            .subtract(0.0, 1.62, 0.0)
-
-        else -> npcLocation.clone()
+    npcLocation: BukkitLocation,
+    scale: Double
+): BukkitLocation {
+    val base = when (npcPose) {
+        NpcPose.SNEAKING -> 0.2
+        NpcPose.SITTING -> 0.62
+        NpcPose.SWIMMING, NpcPose.FALL_FLYING, NpcPose.SLEEPING -> 1.62
+        else -> 0.0
     }
+
+    return npcLocation.clone().subtract(0.0, base * scale, 0.0)
+        .add(0.0, 2.0 * scale, 0.0)
+}
 
 private fun wrapEquipmentSlot(slot: org.bukkit.inventory.EquipmentSlot): EquipmentSlot =
     when (slot) {

--- a/surf-npc-paper/src/main/kotlin/dev/slne/surf/npc/paper/api/PaperSurfNpcApi.kt
+++ b/surf-npc-paper/src/main/kotlin/dev/slne/surf/npc/paper/api/PaperSurfNpcApi.kt
@@ -145,6 +145,19 @@ class PaperSurfNpcApi : SurfNpcApi, Services.Fallback {
             0.0
         )
 
+    override fun getScale(npc: Npc) =
+        npc.getPropertyValue(NpcProperty.Internal.SCALE, Double::class) ?: 1.0
+
+    override fun setScale(npc: Npc, scale: Double) = npcController.editNpc(npc) {
+        this.addProperty(
+            NpcProperty(
+                NpcProperty.Internal.SCALE,
+                scale,
+                NpcPropertyType.Types.DOUBLE_TYPE
+            )
+        )
+    }
+
     override fun isPersistent(npc: Npc) =
         npc.getPropertyValue(NpcProperty.Internal.PERSISTENCE, Boolean::class) ?: false
 
@@ -169,4 +182,6 @@ class PaperSurfNpcApi : SurfNpcApi, Services.Fallback {
         npc: Npc,
         pose: NpcPose
     ) = npcController.setPose(npc, pose)
+
+    override fun getPose(npc: Npc) = npcController.getPose(npc)
 }

--- a/surf-npc-paper/src/main/kotlin/dev/slne/surf/npc/paper/command/sub/NpcCreateCommand.kt
+++ b/surf-npc-paper/src/main/kotlin/dev/slne/surf/npc/paper/command/sub/NpcCreateCommand.kt
@@ -28,12 +28,19 @@ fun CommandAPICommand.npcCreateCommand() = subcommand("create") {
         val type: EntityType by args
         val optionalSkin: String? by args
         val location = player.location
-        val createdBy = player.name
 
         if (!isValidName(name)) {
             player.sendText {
                 appendErrorPrefix()
                 error("Der Npc Name ist ungültig.")
+            }
+            return@playerExecutor
+        }
+
+        if (npcController.npcs.any { it.uniqueName == name }) {
+            player.sendText {
+                appendErrorPrefix()
+                error("Ein Npc mit diesem Namen existiert bereits.")
             }
             return@playerExecutor
         }

--- a/surf-npc-paper/src/main/kotlin/dev/slne/surf/npc/paper/command/sub/NpcInfoCommand.kt
+++ b/surf-npc-paper/src/main/kotlin/dev/slne/surf/npc/paper/command/sub/NpcInfoCommand.kt
@@ -5,7 +5,6 @@ import dev.jorel.commandapi.kotlindsl.getValue
 import dev.jorel.commandapi.kotlindsl.playerExecutor
 import dev.jorel.commandapi.kotlindsl.subcommand
 import dev.slne.surf.api.core.font.toSmallCaps
-import dev.slne.surf.api.core.messages.CommonComponents
 import dev.slne.surf.api.core.messages.adventure.clickRunsCommand
 import dev.slne.surf.api.core.messages.adventure.sendText
 import dev.slne.surf.npc.api.npc.Npc
@@ -38,59 +37,57 @@ fun CommandAPICommand.npcInfoCommand() = subcommand("info") {
             ?: error("NPC ${npc.uniqueName} has no skin data set")
 
         player.sendText {
-            info("Npc Informationen".toSmallCaps(), TextDecoration.BOLD)
             appendNewline()
+            appendInfoPrefix()
+            info("Npc Informationen".toSmallCaps(), TextDecoration.BOLD)
 
-            append(CommonComponents.EM_DASH)
-            appendSpace()
+            appendNewline()
+            appendInfoPrefix()
             variableKey("Name: ")
             variableValue(npc.uniqueName)
-            appendNewline()
 
-            append(CommonComponents.EM_DASH)
-            appendSpace()
+            appendNewline()
+            appendInfoPrefix()
             variableKey("Anzeigename: ")
             append(displayName)
-            appendNewline()
 
-            append(CommonComponents.EM_DASH)
-            appendSpace()
+            appendNewline()
+            appendInfoPrefix()
             variableKey("ID: ")
             variableValue(npc.id)
-            appendNewline()
 
-            append(CommonComponents.EM_DASH)
-            appendSpace()
+            appendNewline()
+            appendInfoPrefix()
             variableKey("Nametag-ID: ")
             variableValue(npc.nameTagId)
-            appendNewline()
 
-            append(CommonComponents.EM_DASH)
-            appendSpace()
+            appendNewline()
+            appendInfoPrefix()
             variableKey("Uuid: ")
             variableValue(npc.npcUuid.toString())
-            appendNewline()
 
-            append(CommonComponents.EM_DASH)
-            appendSpace()
+            appendNewline()
+            appendInfoPrefix()
             append {
                 variableKey("Ort: ")
                 variableValue(location.readableString())
                 clickRunsCommand("/npc teleport ${npc.id}")
             }
-            appendNewline()
 
-            append(CommonComponents.EM_DASH)
-            appendSpace()
+            appendNewline()
+            appendInfoPrefix()
             variableKey("Rotation: ")
             variableValue(rotationType.name)
-            appendNewline()
 
-            append(CommonComponents.EM_DASH)
-            appendSpace()
+            appendNewline()
+            appendInfoPrefix()
             variableKey("Skin: ")
             variableValue(skinData.ownerName)
+
             appendNewline()
+            appendInfoPrefix()
+            variableKey("Größe: ")
+            variableValue(npc.getScale())
         }
     }
 }

--- a/surf-npc-paper/src/main/kotlin/dev/slne/surf/npc/paper/controller/NpcController.kt
+++ b/surf-npc-paper/src/main/kotlin/dev/slne/surf/npc/paper/controller/NpcController.kt
@@ -32,13 +32,14 @@ import org.bukkit.entity.Player
 import org.bukkit.inventory.EquipmentSlot
 import org.bukkit.inventory.ItemStack
 import java.util.*
+import java.util.concurrent.ConcurrentHashMap
 import kotlin.math.atan2
 import kotlin.math.sqrt
 
 val npcController = NpcController()
 
 class NpcController {
-    private val _npcs: Object2ObjectMap<String, Npc> = mutableObject2ObjectMapOf<String, Npc>()
+    private val _npcs = ConcurrentHashMap<String, Npc>()
     val npcs: ObjectSet<Npc> get() = _npcs.values.toObjectSet()
 
     private val equipments =
@@ -147,7 +148,8 @@ class NpcController {
         BukkitPackets.NpcNameTagPackets.NameTagSpawnPacket(
             npc.nameTagId,
             npc.nameTagUuid,
-            npc.getLocation()
+            npc.getLocation(),
+            npc.getScale()
         ).build().sendPacket(uuid)
         BukkitPackets.NpcNameTagPackets.NameTagMetaDataPacket(
             npc.nameTagId,
@@ -157,6 +159,7 @@ class NpcController {
 
         refreshRotation(npc, uuid)
         refreshEquipment(npc, uuid)
+        refreshScale(npc, uuid)
 
         plugin.launch(plugin.globalRegionDispatcher) {
             NpcShowEvent(player, npc).callEvent()
@@ -188,6 +191,10 @@ class NpcController {
         }
     }
 
+    private fun refreshScale(npc: Npc, uuid: UUID) {
+        BukkitPackets.NpcPackets.NpcSetScalePacket(npc.id, npc.getScale()).build().sendPacket(uuid)
+    }
+
     private fun refreshRotation(npc: Npc, uuid: UUID) {
         val rotationType = npc.getRotationType()
         val location = npc.getLocation()
@@ -199,12 +206,17 @@ class NpcController {
             }
 
             NpcRotationType.PER_PLAYER -> {
-                val npcVec = Vector3d(location.x, location.y, location.z)
+                val npcVec = Vector3d(
+                    location.x,
+                    location.y + 1.62 * npc.getScale(),
+                    location.z
+                )
+
                 val playerLoc = player.location
 
                 val dx = playerLoc.x - npcVec.x
                 val dz = playerLoc.z - npcVec.z
-                val dy = playerLoc.y - npcVec.y
+                val dy = (playerLoc.y + player.eyeHeight) - npcVec.y
 
                 val yaw = Math.toDegrees(atan2(-dx, dz)).toFloat()
                 val horizontalDist = sqrt((dx * dx) + (dz * dz))
@@ -296,9 +308,21 @@ class NpcController {
     fun getNpc(id: Int): Npc? = npcs.find { it.id == id }
     fun getNpc(uniqueName: String): Npc? = npcs.find { it.uniqueName == uniqueName }
 
+    fun getPose(npc: Npc) =
+        npc.getPropertyValue(NpcProperty.Internal.POSE, NpcPose::class) ?: NpcPose.STANDING
+
     fun setPose(npc: Npc, pose: NpcPose) {
         val location = npc.getPropertyValue(NpcProperty.Internal.LOCATION, Location::class)
             ?: error("Location is not set for NPC: ${npc.uniqueName}")
+
+        npc.addProperty(
+            NpcProperty(
+                NpcProperty.Internal.POSE,
+                pose,
+                propertyTypeRegistry.get(NpcPropertyType.Types.NPC_POSE_ID)
+                    ?: error("NPC_POSE property type not found")
+            )
+        )
 
         npc.forEachViewer {
             if (pose == NpcPose.SITTING) {
@@ -313,9 +337,7 @@ class NpcController {
 
             BukkitPackets.NpcPackets.NpcPoseChangePacket(npc.id, pose).build().sendPacket(it)
             BukkitPackets.NpcNameTagPackets.NameTagCorrectionPacket(
-                npc.nameTagId,
-                location,
-                pose
+                npc
             ).build().sendPacket(it)
         }
     }

--- a/surf-npc-paper/src/main/kotlin/dev/slne/surf/npc/paper/listener/NpcListener.kt
+++ b/surf-npc-paper/src/main/kotlin/dev/slne/surf/npc/paper/listener/NpcListener.kt
@@ -9,10 +9,8 @@ import com.github.shynixn.mccoroutine.folia.entityDispatcher
 import com.github.shynixn.mccoroutine.folia.launch
 import dev.slne.surf.npc.api.event.NpcCollisionEvent
 import dev.slne.surf.npc.api.event.NpcInteractEvent
-import dev.slne.surf.npc.api.npc.property.NpcProperty
 import dev.slne.surf.npc.paper.controller.npcController
 import dev.slne.surf.npc.paper.plugin
-import org.bukkit.Location
 import org.bukkit.entity.Player
 
 class NpcListener : PacketListener {
@@ -23,10 +21,12 @@ class NpcListener : PacketListener {
             PacketType.Play.Client.PLAYER_POSITION_AND_ROTATION -> {
                 for (npc in npcController.npcs) {
                     val npcLoc = npc.getLocation()
+                    val npcWorld = npcLoc.world ?: continue
 
                     val playerLoc = player.location
+                    val playerWorld = playerLoc.world ?: continue
 
-                    if (playerLoc.world.name != npcLoc.world.name) {
+                    if (playerWorld.name != npcWorld.name) {
                         continue
                     }
 
@@ -34,18 +34,18 @@ class NpcListener : PacketListener {
                         continue
                     }
 
-                    npc.refreshRotation(player.uniqueId)
+                    npc.refreshRotation()
                 }
             }
 
             PacketType.Play.Client.PLAYER_POSITION -> {
                 for (npc in npcController.npcs) {
-                    val npcLoc =
-                        npc.getPropertyValue(NpcProperty.Internal.LOCATION, Location::class)
-                            ?: continue
+                    val npcLoc = npc.getLocation()
+                    val npcWorld = npcLoc.world ?: continue
                     val playerLoc = player.location
+                    val playerWorld = playerLoc.world ?: continue
 
-                    if (playerLoc.world.name != npcLoc.world.name) {
+                    if (playerWorld.name != npcWorld.name) {
                         continue
                     }
 

--- a/surf-npc-paper/src/main/kotlin/dev/slne/surf/npc/paper/property/impl/NpcPosePropertyType.kt
+++ b/surf-npc-paper/src/main/kotlin/dev/slne/surf/npc/paper/property/impl/NpcPosePropertyType.kt
@@ -1,0 +1,17 @@
+package dev.slne.surf.npc.paper.property.impl
+
+import dev.slne.surf.npc.api.npc.NpcPose
+import dev.slne.surf.npc.api.npc.property.NpcPropertyType
+
+class NpcPosePropertyType(override val id: String) : NpcPropertyType {
+    override fun encode(value: Any): String {
+        require(value is NpcPose) { "Expected NpcPose, got ${value::class}" }
+        return value.toString()
+    }
+
+    override fun decode(value: String): NpcPose {
+        return NpcPose.valueOf(value)
+    }
+}
+
+


### PR DESCRIPTION
This pull request introduces support for scaling NPCs (Non-Player Characters) throughout the Surf NPC API and its Paper implementation, along with some related refactoring and minor enhancements. The changes allow users to set and get the scale of NPCs, propagate this property through the API, DSL, and networking layers, and ensure correct behavior in the example plugin and property type registry.

**NPC Scaling Support:**

* Added `setScale(npc: Npc, scale: Double)` and `getScale(npc: Npc): Double` methods to the `SurfNpcApi` interface, and implemented them in `PaperSurfNpcApi`. The scale property is now stored and retrieved as an internal NPC property. [[1]](diffhunk://#diff-8921ec879557f547e29181ae9c86a51fb3aae6be796ba4c7955205f24fe25c0cR55-R62) [[2]](diffhunk://#diff-e4bb8d3f225b1183476f0ce97155dd9b3fc4995fc43596d0931f4e16629cfa80R148-R160)
* Updated the `Npc` data class to expose `setScale` and `getScale` methods, and to delegate all API calls to the static `SurfNpcApi` instance for consistency.
* Extended the DSL (`NpcDslBuilder`) to support setting NPC scale, with a default of `1.0`, and ensured the scale is applied when creating an NPC. [[1]](diffhunk://#diff-4a0b84065fd341541aa206c5300e7068af1865a6b1efe6277490774740b55bc5R53-R54) [[2]](diffhunk://#diff-4a0b84065fd341541aa206c5300e7068af1865a6b1efe6277490774740b55bc5R104-R107) [[3]](diffhunk://#diff-4a0b84065fd341541aa206c5300e7068af1865a6b1efe6277490774740b55bc5L159-R182)
* Modified the example plugin to demonstrate usage of the new scaling feature.

**Networking and Rendering Adjustments:**

* Added new packet types and logic in `PaperPackets.kt` to handle NPC scale, including scaling the name tag's position and updating scale via entity attributes. Adjusted name tag correction and spawn packets to account for scale. [[1]](diffhunk://#diff-0a77493e8c6cb3099a5b2ddc6fc8e3270c79c4a9bda0147a401dfc36d816d42eR149-R164) [[2]](diffhunk://#diff-0a77493e8c6cb3099a5b2ddc6fc8e3270c79c4a9bda0147a401dfc36d816d42eL157-R181) [[3]](diffhunk://#diff-0a77493e8c6cb3099a5b2ddc6fc8e3270c79c4a9bda0147a401dfc36d816d42eL182-R205) [[4]](diffhunk://#diff-0a77493e8c6cb3099a5b2ddc6fc8e3270c79c4a9bda0147a401dfc36d816d42eL259-R286)

**Property System Enhancements:**

* Introduced `SCALE` and `POSE` as internal property keys in `NpcProperty.Internal`, and registered the new property type for pose in the Paper main class. [[1]](diffhunk://#diff-69c3e8620e25c46bbd64714858e14d5960044f31b1ee0f3d75a1e6347134f60aL16-R22) [[2]](diffhunk://#diff-017c3af90c75aab7d6e3839be6ad044d53b1600f8015823d422d43428c2c6909R45)
* Updated `NpcPropertyType.Types` to include `NPC_POSE` and refactored to use `SurfNpcApi` for property type lookups.

**Refactoring and Consistency:**

* Replaced all usages of the old `surfNpcApi` singleton with the static `SurfNpcApi` object for API calls, improving consistency and clarity. [[1]](diffhunk://#diff-831b59b3101d4cf0752faa7acf80ace64fa7de14cc36f69fe29a71746935a66aL76-R118) [[2]](diffhunk://#diff-05537b97c82d4ba6ff88855dc32fc77d65d91c706565ddb815cbfb41c674dadeL3-R3) [[3]](diffhunk://#diff-4a0b84065fd341541aa206c5300e7068af1865a6b1efe6277490774740b55bc5R8-L13)

**Version Bump:**

* Bumped the project version to `1.6.5-SNAPSHOT` in `gradle.properties`.